### PR TITLE
Moving libphonenumber-js, moment and moment-range from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
       "pre-commit": "lint-staged"
     }
   },
+  "dependencies": {
+    "libphonenumber-js": "^1.7.51",
+    "moment": "2.24.0",
+    "moment-range": "^4.0.2"
+  },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.3.1",
     "@vue/cli-plugin-eslint": "^4.3.1",
@@ -66,11 +71,8 @@
     "gulp-sourcemaps": "^2.6.5",
     "husky": "^4.2.5",
     "json-templater": "^1.2.0",
-    "libphonenumber-js": "^1.7.51",
     "lint-staged": "^10.2.2",
     "merge-stream": "^2.0.0",
-    "moment": "2.24.0",
-    "moment-range": "^4.0.2",
     "ncp": "^2.0.0",
     "node-sass": "^4.14.0",
     "nuxt": "^2.12.2",


### PR DESCRIPTION
Hello! I've found out, that when I include `maz-ui` to my project (using npm or yarn) `libphonenumber-js`, `moment` and `moment-range` libraries are not fetched by npm. You can check this by creating an empty project (npm init) and doing `npm i -S maz-ui` -- the `node_modules` folder will only have maz-ui, and no other dependency.

That would be fine, but then when you try to `import { MazPhoneNumberInput } from 'maz-ui'` and/or `{ MazPicker } from 'maz-ui'` the builder will error, saying that dependencies are missing: `libphonenumber-js` for phone input, `moment` and `moment-range` for datepicker.

I've checked and found out that this is happening because those libraries are in `devDependencies` (`package.json`), and I think when you're building for production those libraries are not downloaded by `npm install`. So I've tested this by moving them to `dependencies` and running `npm install` -- _then_ npm downloaded them successfully.

Btw your separate repo for [vue-phone-number-input](https://github.com/LouisMazel/vue-phone-number-input/blob/master/package.json) actually has `libphonenumber-js` in `dependencies`, not `devDependencies` :)

For now I have to manually include those libraries into my project's `package.json` file for some of `maz-ui`'s components  to work:
- `libphonenumber-js` for `MazPhoneNumberInput`
- `moment` and `moment-range` for `MazPicker`