### PR TITLE
[Dependencies] Moving some more dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,11 @@
   "dependencies": {
     "libphonenumber-js": "^1.7.51",
     "moment": "2.24.0",
-    "moment-range": "^4.0.2"
+    "moment-range": "^4.0.2",
+    "plotly.js-dist": "^1.54.1",
+    "vue2-dropzone": "3.5.2",
+    "v-click-outside": "^3.0.1",
+    "vuedraggable": "^2.23.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.3.1",
@@ -76,7 +80,6 @@
     "ncp": "^2.0.0",
     "node-sass": "^4.14.0",
     "nuxt": "^2.12.2",
-    "plotly.js-dist": "^1.54.1",
     "prettier": "1.19.1",
     "progress-bar-webpack-plugin": "^2.1.0",
     "rimraf": "^3.0.2",
@@ -87,14 +90,11 @@
     "stylelint-order": "^3.1.1",
     "stylelint-scss": "^3.17.1",
     "uppercamelcase": "^3.0.0",
-    "v-click-outside": "^3.0.1",
     "vue": "^2.6.11",
     "vue-highlightjs": "^1.3.3",
     "vue-router": "^3.1.6",
     "vue-template-compiler": "^2.6.11",
     "vue-virtual-scroller": "^1.0.10",
-    "vue2-dropzone": "3.5.2",
-    "vuedraggable": "^2.23.2",
     "webpack-cli": "^3.3.11"
   },
   "engines": {


### PR DESCRIPTION
Here's what is moved from `devDependencies` to `dependencies`:
- `plotly.js-dist` (for `MazPlotly` to work)
- `vue2-dropzone` (for `MazDropzone` to work)
- `v-click-outside` (for `MazDialog` and `MazBottomSheet` to work)
- `vuedraggable` (for `MazDraggableList` to work)