### PR TITLE
[MazPhoneNumberInput] Add Andorra again

### DIFF
--- a/packages/components/MazPhoneNumberInput/constantes/js/phoneCodeCountries.js
+++ b/packages/components/MazPhoneNumberInput/constantes/js/phoneCodeCountries.js
@@ -19,11 +19,11 @@ const allCountries = [
     'as',
     '1684'
   ],
-  // [
-  //   'Andorra',
-  //   'ad',
-  //   '376'
-  // ],
+  [
+    'Andorra',
+    'ad',
+    '376'
+  ],
   [
     'Angola',
     'ao',


### PR DESCRIPTION
Andorra was commented out, any reason for this? It works fine when adding it back in.

![Screen Shot 2021-03-19 at 14 01 08](https://user-images.githubusercontent.com/398400/111784313-95e4e500-88bb-11eb-9489-54f0826b2db4.png)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing

**Other information:**
