### PR TITLE
[MazPhoneNumberInput] Enhancement -- Include phoneNumber on invalid response

### DIFF
--- a/packages/components/MazPhoneNumberInput/utils/index.js
+++ b/packages/components/MazPhoneNumberInput/utils/index.js
@@ -26,7 +26,8 @@ export const getResultsFromPhoneNumber = (phoneNumber, countryCode) => {
 
   let results = {
     countryCode,
-    isValid: false
+    isValid: false,
+    phoneNumber, // useful for identifying non-numeric characters being entered.
   }
 
   if (parsing) {


### PR DESCRIPTION
By re-introducing this value as part of the response for an invalid number, it will send back all characters that were entered. This is useful for the case where switching between the phone number input and a regular input to enter an email address or username. When the response comes back with invalid and no formatNational value, we can assume it's not a phone number and switch to a regular input while also populating the phoneNumber value into the regular input. This was previously done in `vue-phone-number-input`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
