### PR TITLE
[Bugfix] MazPhoneNumberInput: props countriesHeight fixed

### DIFF
--- a/packages/components/MazPhoneNumberInput/_main.vue
+++ b/packages/components/MazPhoneNumberInput/_main.vue
@@ -13,7 +13,7 @@
       :search="!noSearch"
       :position="position"
       :search-placeholder="t.countrySelectorSearchPlaceholder"
-      :items-height="countriesHeight"
+      :item-height="countriesHeight"
       :error="shouldChooseCountry"
       :hint="shouldChooseCountry ? t.countrySelectorError : null"
       :size="size"


### PR DESCRIPTION
Hello! Property "countriesHeight" of the component MazPhoneNumberInput  fixed
