### PR TITLE
refactor(maz-ui): MazPhoneNumberInput - add possibility to choose between placeholder and label for the input

### DIFF
--- a/packages/lib/components/MazPhoneNumberInput.vue
+++ b/packages/lib/components/MazPhoneNumberInput.vue
@@ -72,7 +72,8 @@
       :locales
       :no-formatting-as-you-type
       :auto-format
-      :label="placeholder"
+      :label="label"
+      :placeholder="placeholder"
       @update:model-value="
         onPhoneNumberChanged({
           newPhoneNumber: $event,
@@ -158,6 +159,8 @@
     id?: string
     /** Placeholder of the input */
     placeholder?: string
+    /** label of the input */
+    label?: string
     /** List of country codes to place first in the select list - Ex: ['FR', 'BE', 'GE'] */
     preferredCountries?: CountryCode[]
     /** List of country codes to be removed from the select list - Ex: ['FR', 'BE', 'GE'] */

--- a/packages/lib/components/MazPhoneNumberInput/PhoneInput.vue
+++ b/packages/lib/components/MazPhoneNumberInput/PhoneInput.vue
@@ -5,6 +5,7 @@
     :model-value="modelValue"
     v-bind="$attrs"
     :label="inputLabel"
+    :placeholder="computedPlaceholder"
     :disabled
     :color
     :error
@@ -54,6 +55,7 @@
       class: undefined,
       style: undefined,
       label: undefined,
+      placeholder: undefined,
     },
   )
 
@@ -74,6 +76,23 @@
   const inputLabel = computed(() => {
     if (props.label) {
       return props.label
+    }
+
+    const defaultPlaceholder = props.locales.phoneInput.placeholder
+
+    if (props.noExample || !examples.value) {
+      return defaultPlaceholder
+    } else {
+      const example = getPhoneNumberExample(examples.value, selectedCountry.value)
+      return results.value?.isValid || !example
+        ? defaultPlaceholder
+        : `${props.locales.phoneInput.example} ${example}`
+    }
+  })
+
+  const computedPlaceholder = computed(() => {
+    if (props.placeholder) {
+      return props.placeholder
     }
 
     const defaultPlaceholder = props.locales.phoneInput.placeholder


### PR DESCRIPTION
# Issue

- #1076 

---

- [ ] Bug fix 
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Dependencies
- [ ] Documentation
- [ ] Tests
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [X] Yes
- [ ] No

**Other information:**
Steps:
1. Define a placeholder prop for the MazPhoneNumberInput.vue
2. Bind the prop to the PhoneInput.vue
3. Define a computed value for the placeholder that displays a default placeholder when none is entered
4. Bind the label prop to the computed placeholder
