### PR TITLE
fix(cli): path for files creation

### DIFF
--- a/tools/cli/src/commands/create-files/create-documentation-file.ts
+++ b/tools/cli/src/commands/create-files/create-documentation-file.ts
@@ -13,7 +13,7 @@ export async function createDocumentFile({
   filename: string
   filenameKebab: string
 }): Promise<void> {
-  const DOCS_FILE_OUTPUT = resolve(_dirname, `../../../../docs/src/components/${filenameKebab}.md`)
+  const DOCS_FILE_OUTPUT = resolve(_dirname, `../../../../../apps/docs/src/components/${filenameKebab}.md`)
 
   const documentationFileTemplate = `---
 title: ${filename}

--- a/tools/cli/src/commands/create-files/create-library-component-file.ts
+++ b/tools/cli/src/commands/create-files/create-library-component-file.ts
@@ -13,7 +13,7 @@ export async function createLibraryComponentFile({
   filename: string
   filenameKebab: string
 }): Promise<void> {
-  const COMPONENT_FILE_OUTPUT = resolve(_dirname, `../../../../lib/src/components/${filename}.vue`)
+  const COMPONENT_FILE_OUTPUT = resolve(_dirname, `../../../../../packages/lib/src/components/${filename}.vue`)
 
   const componentTemplate = `<template>
   <div class="m-${filenameKebab.split('-')[1]} m-reset-css">${filename}</div>

--- a/tools/cli/src/commands/create-files/create-library-test-file.ts
+++ b/tools/cli/src/commands/create-files/create-library-test-file.ts
@@ -26,7 +26,7 @@ describe('${filename}', () => {
   try {
     const TEST_FILE_OUTPUT = resolve(
       _dirname,
-      `../../../../lib/tests/specs/components/${filename}.spec.ts`,
+      `../../../../../packages/lib/tests/specs/components/${filename}.spec.ts`,
     )
 
     await writeFile(TEST_FILE_OUTPUT, testComponentTemplate)


### PR DESCRIPTION
## Description

Fixed incorrect file paths in CLI create-files commands. The paths were updated to reflect the correct monorepo structure, changing from `lib/` to `packages/lib/` and `docs/` to `apps/docs/` directories.

## Affected Packages

<!-- Check all packages that are affected by this PR -->

- [ ] `maz-ui` (main library - components, composables and plugins)
- [ ] `@maz-ui/nuxt` (Nuxt module)
- [ ] `@maz-ui/icons` (icon library)
- [ ] `@maz-ui/themes` (theme system)
- [ ] `@maz-ui/translations` (i18n)
- [ ] `@maz-ui/utils` (utilities)
- [x] `@maz-ui/cli` (CLI tools)
- [ ] `@maz-ui/eslint-config` (ESLint config)
- [ ] `@maz-ui/mcp` (MCP of maz-ui)
- [ ] `@maz-ui/node` (Node utilities)
- [ ] `docs` (documentation)
- [ ] Other:

## Type of Change

<!-- Check the type of change your PR introduces -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style/UI update (formatting, renaming, etc; no functional changes)
- [ ] Refactor (no functional changes, code improvements)
- [ ] Documentation update
- [ ] Tests (adding missing tests or correcting existing tests)
- [ ] Build/CI related changes
- [ ] Dependencies update
- [ ] Performance improvements
- [ ] Other (please describe):

## Related Issues

<!-- Link to related issues -->
<!-- Use "Closes #123" if this PR closes an issue -->
<!-- Use "Relates to #123" if this PR is related to an issue -->

## Documentation

<!-- Describe how you tested your changes -->

- [ ] Documentation updated if needed

## Screenshots/Demo

<!-- If applicable, add screenshots or a demo link -->

## Additional Context

<!-- Add any other context about the PR here -->

The CLI create-files commands were using incorrect relative paths that didn't match the actual monorepo structure. This fix ensures that when users create new components through the CLI, the files are generated in the correct directories:
- Components: `packages/lib/src/components/`
- Tests: `packages/lib/tests/specs/components/`
- Documentation: `apps/docs/src/components/`