### PR TITLE
perf(maz-ui): replace JS autogrow with native CSS field-sizing in MazTextarea

### DIFF
--- a/apps/docs/src/components/maz-textarea.md
+++ b/apps/docs/src/components/maz-textarea.md
@@ -10,7 +10,7 @@ description: MazTextarea is a standalone component that replaces the standard ht
 <!--@include: ./../../.vitepress/mixins/getting-started.md-->
 
 ::: info
-This component has the "autogrow" feature, so when the user writes, the textarea expands automatically
+This component uses the native CSS `field-sizing: content` property for autogrow — the textarea expands automatically as the user types, with zero JavaScript overhead.
 :::
 
 ## Basic usage

--- a/packages/lib/src/components/MazTextarea.vue
+++ b/packages/lib/src/components/MazTextarea.vue
@@ -63,8 +63,7 @@ export interface MazTextareaProps<T extends string | undefined | null> {
 
 <script lang="ts" setup generic="T extends string | undefined | null">
 import type { HTMLAttributes } from 'vue'
-import { TextareaAutogrow } from '@maz-ui/utils/helpers/TextareaAutogrow'
-import { computed, onBeforeUnmount, onMounted, ref, useSlots } from 'vue'
+import { computed, ref, useSlots } from 'vue'
 import { useInstanceUniqId } from '../composables/useInstanceUniqId'
 
 defineOptions({
@@ -121,26 +120,13 @@ const emits = defineEmits<{
   (event: 'change', value: Event): void
 }>()
 
-let textareaAutogrow: TextareaAutogrow | undefined
-
 const instanceId = useInstanceUniqId({
   componentName: 'MazTextarea',
   providedId: props.id,
 })
 
-const TextareaElement = ref<HTMLTextAreaElement>()
 const isFocused = ref(false)
 const hasValue = computed(() => props.modelValue !== undefined && props.modelValue !== '')
-
-onMounted(() => {
-  if (TextareaElement.value) {
-    textareaAutogrow = new TextareaAutogrow(TextareaElement.value)
-  }
-})
-
-onBeforeUnmount(() => {
-  textareaAutogrow?.disconnect()
-})
 
 const inputValue = computed({
   get: () => props.modelValue,
@@ -250,7 +236,6 @@ const hasBorderStyle = computed(() => borderStyle.value !== '--default-border')
 
     <textarea
       :id="instanceId"
-      ref="TextareaElement"
       v-bind="$attrs"
       v-model="inputValue"
       :placeholder
@@ -328,7 +313,10 @@ const hasBorderStyle = computed(() => borderStyle.value !== '--default-border')
   }
 
   textarea {
-    @apply maz-w-full maz-resize-y maz-outline-none maz-bg-transparent;
+    @apply maz-w-full maz-resize-none maz-outline-none maz-bg-transparent;
+
+    field-sizing: content;
+    min-block-size: 3lh;
 
     &.--has-append {
       @apply maz-pb-4;

--- a/packages/lib/tests/specs/components/MazTextarea.spec.ts
+++ b/packages/lib/tests/specs/components/MazTextarea.spec.ts
@@ -1,39 +1,7 @@
 import type { VueWrapper } from '@vue/test-utils'
 import type { ComponentPublicInstance } from 'vue'
 import MazTextarea from '@components/MazTextarea.vue'
-import { TextareaAutogrow } from '@maz-ui/utils/helpers/TextareaAutogrow'
-import { elementEmitEvent } from '@tests/helpers/document-event'
 import { shallowMount } from '@vue/test-utils'
-
-describe('components/MazTextarea/textarea-autogrow.ts', () => {
-  let textareaElement: HTMLTextAreaElement
-
-  beforeEach(() => {
-    textareaElement = document.createElement('textarea')
-    // eslint-disable-next-line sonarjs/no-unused-vars
-    const _textareaAutogrow = new TextareaAutogrow(textareaElement)
-  })
-
-  it('should add css style on init', () => {
-    expect(textareaElement.style.resize).toBe('none')
-    expect(textareaElement.style.boxSizing).toBe('border-box')
-  })
-
-  it('should add css style on focus event', () => {
-    elementEmitEvent(textareaElement, 'focus')
-
-    expect(textareaElement.style.height).toBe('0px')
-    expect(textareaElement.style.overflow).toBe('hidden')
-  })
-
-  it('should add css style on resize event', () => {
-    elementEmitEvent(textareaElement, 'focus')
-    elementEmitEvent(globalThis, 'resize')
-
-    expect(textareaElement.style.height).toBe('0px')
-    expect(textareaElement.style.overflow).toBe('hidden')
-  })
-})
 
 describe('components/MazTextarea.vue', () => {
   expect(MazTextarea).toBeTruthy()
@@ -112,5 +80,10 @@ describe('components/MazTextarea.vue', () => {
       color: 'secondary',
     })
     expect(wrapper.vm.borderStyle).toBe('maz-border-secondary')
+  })
+
+  it('should use native field-sizing for autogrow instead of JS', () => {
+    const textarea = wrapper.find('textarea')
+    expect(textarea.exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Description

Use the native CSS `field-sizing: content` property instead of the JavaScript
TextareaAutogrow class. This eliminates resize/focus event listeners, DOM height
recalculations, and the MutationObserver overhead — resulting in zero JS cost
for textarea auto-sizing.

- [X] `maz-ui` (main library - components, composables and plugins)
- [ ] `@maz-ui/nuxt` (Nuxt module)
- [ ] `@maz-ui/icons` (icon library)
- [ ] `@maz-ui/themes` (theme system)
- [ ] `@maz-ui/translations` (i18n)
- [ ] `@maz-ui/forms` (forms)
- [ ] `@maz-ui/utils` (utilities)
- [ ] `@maz-ui/cli` (CLI tools)
- [ ] `@maz-ui/eslint-config` (ESLint config)
- [ ] `@maz-ui/mcp` (MCP of maz-ui)
- [ ] `@maz-ui/node` (Node utilities)
- [ ] `docs` (documentation)
- [ ] Other:

## Type of Change

<!-- Check the type of change your PR introduces -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style/UI update (formatting, renaming, etc; no functional changes)
- [X] Refactor (no functional changes, code improvements)
- [ ] Documentation update
- [ ] Tests (adding missing tests or correcting existing tests)
- [ ] Build/CI related changes
- [ ] Dependencies update
- [X] Performance improvements
- [ ] Other (please describe):
