### PR TITLE
fix(maz-ui): add TypeScript 6 compatibility for CSS subpath exports

### DIFF
--- a/packages/lib/build/ViteCompileStyles.ts
+++ b/packages/lib/build/ViteCompileStyles.ts
@@ -55,6 +55,13 @@ export function ViteCompileStyles(): Plugin {
         await compileScss()
 
         logger.success('[CompileStyles] ✅ scss compiled')
+
+        // Write type declaration stubs for TypeScript 6 compatibility (TS2882)
+        // Side-effect CSS imports require a `types` field in package.json subpath exports
+        writeFileSync(resolve(cssDir, 'main.css.d.ts'), 'export {}\n')
+        writeFileSync(resolve(cssDir, 'aos.css.d.ts'), 'export {}\n')
+
+        logger.success('[CompileStyles] ✅ type declarations written')
       }
       catch (error) {
         logger.error('[CompileStyles] 🔴 error while compiling styles', error)

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -109,8 +109,14 @@
       "module": "./dist/tailwindcss/*.js",
       "default": "./dist/tailwindcss/*.js"
     },
-    "./styles": "./dist/css/main.css",
-    "./aos-styles": "./dist/css/aos.css",
+    "./styles": {
+      "types": "./dist/css/main.css.d.ts",
+      "default": "./dist/css/main.css"
+    },
+    "./aos-styles": {
+      "types": "./dist/css/aos.css.d.ts",
+      "default": "./dist/css/aos.css"
+    },
     "./*": "./*"
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Converts `./styles` and `./aos-styles` subpath exports in `packages/lib/package.json` from bare CSS strings to object form with an explicit `types` field
- Adds `main.css.d.ts` and `aos.css.d.ts` stub generation to the `ViteCompileStyles` Vite plugin so declarations are produced at build time

## Root Cause

TypeScript 6 introduced **TS2882**: any side-effect import (`import 'maz-ui/styles'`) that resolves to a subpath export without a `types` field is rejected at compile time. The previous exports were bare strings pointing directly to the CSS files:

```json
"./styles": "./dist/css/main.css",
"./aos-styles": "./dist/css/aos.css"
```

TypeScript 6 has no type information to validate these imports against, so it errors.

## Fix

```json
"./styles": {
  "types": "./dist/css/main.css.d.ts",
  "default": "./dist/css/main.css"
},
"./aos-styles": {
  "types": "./dist/css/aos.css.d.ts",
  "default": "./dist/css/aos.css"
}
```

The `.d.ts` stubs (`export {}`) tell TypeScript the import is a valid side-effect module with no bindings. They are generated automatically by the `ViteCompileStyles` plugin alongside the compiled CSS files — no manual maintenance needed.

## Test Plan

- [ ] Build `packages/lib` (`pnpm -F maz-ui build`) — verify `dist/css/main.css.d.ts` and `dist/css/aos.css.d.ts` are created
- [ ] In a TypeScript 6 project, verify `import 'maz-ui/styles'` no longer raises TS2882

Closes #1531