### PR TITLE
feat(flags): add flagsBaseUrl option for local flag hosting

### DIFF
--- a/packages/lib/src/components/MazInputPhoneNumber.vue
+++ b/packages/lib/src/components/MazInputPhoneNumber.vue
@@ -314,6 +314,12 @@ export interface MazInputPhoneNumberProps {
    */
   orientation?: 'row' | 'col' | 'responsive'
   /**
+   * Base URL for country flag images. Defaults to flagcdn.com.
+   * Override this to serve flags from a local path for offline/hybrid apps.
+   * @example "/assets/flags"
+   */
+  flagsBaseUrl?: string
+  /**
    * Meta attributes of the country input
    * @type {Record<string, unknown>}
    * @default { autocomplete: 'off', name: 'country' }
@@ -605,6 +611,7 @@ provide<MazInputPhoneNumberInjectedData>('mazInputPhoneNumberData', {
       :countries-list="customCountriesList"
       :list-position
       :hide-flags
+      :flags-base-url="flagsBaseUrl"
       :search
       :block
       :error="error || (validationError ? !!phoneNumber && !selectedCountry : false)"

--- a/packages/lib/src/components/MazSelectCountry.vue
+++ b/packages/lib/src/components/MazSelectCountry.vue
@@ -115,6 +115,13 @@ export interface MazSelectCountryProps<Option extends { name: string, code: Disp
   hint?: string
 
   /**
+   * Base URL for country flag images. Defaults to flagcdn.com.
+   * Override this to serve flags from a local path for offline/hybrid apps.
+   * @example "/assets/flags"
+   */
+  flagsBaseUrl?: string
+
+  /**
    * Options
    * @type {Option[]}
    */
@@ -188,6 +195,7 @@ const {
   style,
   codesType,
   formatInputValue,
+  flagsBaseUrl,
 } = defineProps<MazSelectCountryProps<Option>>()
 
 defineEmits<{
@@ -246,7 +254,7 @@ const messages = computed<MazUiTranslationsNestedSchema['selectCountry']>(() => 
 }))
 
 function getFlagUrl(code: Option['code'], size: Parameters<typeof getCountryFlagUrl>[1] = 'h20') {
-  return getCountryFlagUrl(code.slice(0, 2), size) || getCountryFlagUrl(code.slice(3, 5), size) || getCountryFlagUrl(code, size)
+  return getCountryFlagUrl(code.slice(0, 2), size, flagsBaseUrl) || getCountryFlagUrl(code.slice(3, 5), size, flagsBaseUrl) || getCountryFlagUrl(code, size, flagsBaseUrl)
 }
 
 const flagUrl = computed(() => {

--- a/packages/lib/tests/specs/components/MazSelectCountry.spec.ts
+++ b/packages/lib/tests/specs/components/MazSelectCountry.spec.ts
@@ -16,7 +16,10 @@ vi.mock('@maz-ui/utils/helpers/getBrowserLocale', () => ({
 }))
 
 vi.mock('@maz-ui/utils/helpers/getCountryFlagUrl', () => ({
-  getCountryFlagUrl: (code: string) => `https://flagcdn.com/h20/${code.toLowerCase()}.png`,
+  getCountryFlagUrl: (code: string, _size?: string, baseUrl?: string) => {
+    const base = (baseUrl ?? 'https://flagcdn.com').replace(/\/$/, '')
+    return `${base}/h20/${code.toLowerCase()}.png`
+  },
 }))
 
 vi.mock('../composables/useDisplayNames', () => ({
@@ -476,6 +479,22 @@ describe('mazSelectCountry', () => {
     })
     const mazLazyImg = wrapper.findComponent({ name: 'MazLazyImg' })
     expect(mazLazyImg.exists()).toBe(false)
+  })
+
+  it('renders flag from custom flagsBaseUrl when provided', async () => {
+    const wrapper = await getWrapper({
+      props: {
+        modelValue: 'FR',
+        flagsBaseUrl: '/assets/flags',
+      },
+      shallow: false,
+    })
+    await vi.dynamicImportSettled()
+
+    const mazLazyImg = wrapper.findComponent(MazLazyImg)
+
+    expect(mazLazyImg.exists()).toBe(true)
+    expect(mazLazyImg.props('src')).toBe('/assets/flags/h20/fr.png')
   })
 
   it('renders with custom option value key', async () => {

--- a/packages/utils/src/helpers/__tests__/getCountryFlagUrl.spec.ts
+++ b/packages/utils/src/helpers/__tests__/getCountryFlagUrl.spec.ts
@@ -1,4 +1,4 @@
-import { getCountryFlagUrl } from '../getCountryFlagUrl'
+import { FLAG_CDN_BASE_URL, getCountryFlagUrl } from '../getCountryFlagUrl'
 
 describe('given getCountryFlagUrl function', () => {
   describe('when called with a supported country code', () => {
@@ -29,6 +29,30 @@ describe('given getCountryFlagUrl function', () => {
     it('then it should return undefined', () => {
       expect(getCountryFlagUrl('zz')).toBeUndefined()
       expect(getCountryFlagUrl('invalid')).toBeUndefined()
+    })
+  })
+
+  describe('when called with a custom baseUrl', () => {
+    it('then it should use the custom base URL for SVG', () => {
+      expect(getCountryFlagUrl('fr', undefined, '/assets/flags')).toBe('/assets/flags/fr.svg')
+    })
+
+    it('then it should use the custom base URL for PNG with size', () => {
+      expect(getCountryFlagUrl('us', 'h20', '/assets/flags')).toBe('/assets/flags/h20/us.png')
+    })
+
+    it('then it should strip trailing slash from baseUrl', () => {
+      expect(getCountryFlagUrl('de', undefined, '/assets/flags/')).toBe('/assets/flags/de.svg')
+    })
+
+    it('then it should return undefined for unsupported codes even with custom baseUrl', () => {
+      expect(getCountryFlagUrl('zz', undefined, '/assets/flags')).toBeUndefined()
+    })
+  })
+
+  describe('FLAG_CDN_BASE_URL constant', () => {
+    it('then it should export the default flagcdn.com base URL', () => {
+      expect(FLAG_CDN_BASE_URL).toBe('https://flagcdn.com')
     })
   })
 })

--- a/packages/utils/src/helpers/getCountryFlagUrl.ts
+++ b/packages/utils/src/helpers/getCountryFlagUrl.ts
@@ -46,7 +46,9 @@ const _supportedCodes = ['ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'ao', 'aq', '
 
 type SupportedCodes = typeof _supportedCodes[number]
 
-export function getCountryFlagUrl(countryIsoCode: SupportedCodes | string, size?: Size) {
+export const FLAG_CDN_BASE_URL = 'https://flagcdn.com'
+
+export function getCountryFlagUrl(countryIsoCode: SupportedCodes | string, size?: Size, baseUrl?: string) {
   const code = countryIsoCode.toLowerCase()
 
   if (!_supportedCodes.includes(code as SupportedCodes)) {
@@ -55,5 +57,7 @@ export function getCountryFlagUrl(countryIsoCode: SupportedCodes | string, size?
     return undefined
   }
 
-  return size ? `https://flagcdn.com/${size}/${code}.png` : `https://flagcdn.com/${code}.svg`
+  const base = (baseUrl ?? FLAG_CDN_BASE_URL).replace(/\/$/, '')
+
+  return size ? `${base}/${size}/${code}.png` : `${base}/${code}.svg`
 }


### PR DESCRIPTION
## Summary

- Add optional `baseUrl` parameter to `getCountryFlagUrl()` helper (defaults to `https://flagcdn.com`)
- Add `flagsBaseUrl` prop to `MazSelectCountry` component that passes through to the flag URL generator
- Add `flagsBaseUrl` prop to `MazInputPhoneNumber` component that passes through to `MazSelectCountry`
- Export `FLAG_CDN_BASE_URL` constant from the utils helper for reference

## Motivation

Closes #1196 — Hybrid/offline apps (e.g., Capacitor/Cordova) cannot reach flagcdn.com when running offline. This change lets consumers host country flags locally and point the components to their own asset path.

## Usage

```vue
<!-- Serve flags from your local app assets instead of flagcdn.com -->
<MazInputPhoneNumber flags-base-url="/assets/flags" />
<MazSelectCountry flags-base-url="/assets/flags" />
```

The URL pattern mirrors flagcdn.com:
- SVG (no size): `{flagsBaseUrl}/{code}.svg`
- PNG (with size): `{flagsBaseUrl}/{size}/{code}.png`

## Test Plan

- [x] `getCountryFlagUrl` tests: 11 passing (new tests cover custom baseUrl, trailing-slash stripping, unsupported codes with custom baseUrl, and the exported constant)
- [x] `MazSelectCountry` tests: 61 passing (new test validates flag renders from custom `flagsBaseUrl`)
- [x] `MazInputPhoneNumber` tests: 14 passing
- [x] All pre-existing tests unaffected (default behavior unchanged — falls back to `https://flagcdn.com` when no `flagsBaseUrl` provided)