### PR TITLE
refactor(maz-ui): reduce CSS bundle size with CSS variables

### DIFF
--- a/apps/docs/src/components/maz-badge.md
+++ b/apps/docs/src/components/maz-badge.md
@@ -55,6 +55,7 @@ description: MazBadge is a standalone component to show short text in colored co
     'contrast',
     'accent',
     'background',
+    'transparent',
   ]
 </script>
 
@@ -89,6 +90,7 @@ const colors = [
   'contrast',
   'accent',
   'background',
+  'transparent',
 ]
 </script>
 
@@ -123,6 +125,7 @@ const colors = [
     'contrast',
     'accent',
     'background',
+    'transparent',
   ]
 </script>
 
@@ -214,6 +217,7 @@ const roundedSize = ['none', 'sm', 'md', 'lg', 'xl', 'full']
     'contrast',
     'accent',
     'background',
+    'transparent',
   ]
 
   const roundedSize = ['none', 'sm', 'md', 'lg', 'xl', 'full']

--- a/packages/lib/src/components/MazBadge.vue
+++ b/packages/lib/src/components/MazBadge.vue
@@ -66,8 +66,10 @@ const badgeStyle = computed<CSSProperties>(() => {
     ...base,
     '--m-badge-bg': `var(--maz-${c})`,
     '--m-badge-fg': `var(--maz-${c}-foreground)`,
-    '--m-badge-pastel-bg': `var(--maz-${c}-${pastelShade})`,
-    '--m-badge-pastel-fg': `var(--maz-${pastelFg})`,
+    ...(pastel && {
+      '--m-badge-pastel-bg': `var(--maz-${c}-${pastelShade})`,
+      '--m-badge-pastel-fg': `var(--maz-${pastelFg})`,
+    }),
   }
 })
 </script>
@@ -137,7 +139,7 @@ const badgeStyle = computed<CSSProperties>(() => {
   }
 
   &.--surface {
-    @apply maz-bg-surface maz-text-foreground;
+    @apply maz-border-surface maz-bg-surface maz-text-foreground;
 
     &.--outlined {
       @apply maz-border-divider maz-bg-transparent;
@@ -146,6 +148,10 @@ const badgeStyle = computed<CSSProperties>(() => {
     &.--pastel {
       @apply maz-border-surface-600 maz-bg-surface-600;
     }
+  }
+
+  &.--transparent {
+    @apply maz-border-transparent maz-bg-transparent;
   }
 }
 </style>

--- a/packages/lib/src/components/MazBadge.vue
+++ b/packages/lib/src/components/MazBadge.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
+import type { CSSProperties } from 'vue'
 import type { MazColor } from './types'
+import { computed } from 'vue'
 import { getColor } from './types'
 
 export type MazBadgeColor = MazColor | 'background'
@@ -40,13 +42,33 @@ export interface MazBadgeProps {
   roundedSize?: MazBadgeRoundedSize
 }
 
-withDefaults(defineProps<MazBadgeProps>(), {
-  color: 'primary',
-  size: '0.8em',
-  nowrap: false,
-  outlined: false,
-  pastel: false,
-  roundedSize: 'md',
+const {
+  color = 'primary',
+  size = '0.8em',
+  nowrap = false,
+  outlined = false,
+  pastel = false,
+  roundedSize = 'md',
+} = defineProps<MazBadgeProps>()
+
+const resolvedColor = computed(() => getColor(color))
+
+const badgeStyle = computed<CSSProperties>(() => {
+  const c = resolvedColor.value
+  const base: Record<string, string> = { fontSize: size }
+  if (c === 'surface' || c === 'transparent')
+    return base
+
+  const pastelFg = c === 'contrast' ? 'contrast-foreground' : `${c}-700`
+  const pastelShade = c === 'destructive' ? '200' : '50'
+
+  return {
+    ...base,
+    '--m-badge-bg': `var(--maz-${c})`,
+    '--m-badge-fg': `var(--maz-${c}-foreground)`,
+    '--m-badge-pastel-bg': `var(--maz-${c}-${pastelShade})`,
+    '--m-badge-pastel-fg': `var(--maz-${pastelFg})`,
+  }
 })
 </script>
 
@@ -54,11 +76,11 @@ withDefaults(defineProps<MazBadgeProps>(), {
   <span
     class="m-badge m-reset-css"
     :class="[
-      `--${getColor(color)}`,
+      `--${resolvedColor}`,
       { '--outlined': outlined, '--pastel': pastel, '--nowrap': nowrap },
       `--rounded-${roundedSize}`,
     ]"
-    :style="{ fontSize: size }"
+    :style="badgeStyle"
   >
     <!-- @slot Badge content -->
     <slot />
@@ -71,6 +93,9 @@ withDefaults(defineProps<MazBadgeProps>(), {
 
   padding: 0.25em 0.5em;
   line-height: 1.4em;
+  background-color: hsl(var(--m-badge-bg));
+  color: hsl(var(--m-badge-fg));
+  border-color: hsl(var(--m-badge-bg));
 
   &.--nowrap {
     @apply maz-whitespace-nowrap;
@@ -98,100 +123,17 @@ withDefaults(defineProps<MazBadgeProps>(), {
     }
   }
 
-  &.--primary {
-    @apply maz-border-primary maz-bg-primary maz-text-primary-foreground;
+  &.--outlined {
+    @apply maz-bg-transparent;
 
-    &.--outlined {
-      @apply maz-border-primary maz-bg-transparent maz-text-primary;
-    }
-
-    &.--pastel {
-      @apply maz-border-primary-50 maz-bg-primary-50 maz-text-primary-700;
-    }
+    color: hsl(var(--m-badge-bg));
+    border-color: hsl(var(--m-badge-bg));
   }
 
-  &.--info {
-    @apply maz-border-info maz-bg-info maz-text-info-foreground;
-
-    &.--outlined {
-      @apply maz-border-info maz-bg-transparent maz-text-info;
-    }
-
-    &.--pastel {
-      @apply maz-border-info-50 maz-bg-info-50 maz-text-info-700;
-    }
-  }
-
-  &.--secondary {
-    @apply maz-border-secondary maz-bg-secondary maz-text-secondary-foreground;
-
-    &.--outlined {
-      @apply maz-border-secondary maz-bg-transparent maz-text-secondary;
-    }
-
-    &.--pastel {
-      @apply maz-border-secondary-50 maz-bg-secondary-50 maz-text-secondary-700;
-    }
-  }
-
-  &.--destructive {
-    @apply maz-border-destructive maz-bg-destructive maz-text-destructive-foreground;
-
-    &.--outlined {
-      @apply maz-border-destructive maz-bg-transparent maz-text-destructive;
-    }
-
-    &.--pastel {
-      @apply maz-border-destructive-200 maz-bg-destructive-200 maz-text-destructive-700;
-    }
-  }
-
-  &.--warning {
-    @apply maz-border-warning maz-bg-warning maz-text-warning-foreground;
-
-    &.--outlined {
-      @apply maz-border-warning maz-bg-transparent maz-text-warning;
-    }
-
-    &.--pastel {
-      @apply maz-border-warning-50 maz-bg-warning-50 maz-text-warning-700;
-    }
-  }
-
-  &.--success {
-    @apply maz-border-success maz-bg-success maz-text-success-foreground;
-
-    &.--outlined {
-      @apply maz-border-success maz-bg-transparent maz-text-success;
-    }
-
-    &.--pastel {
-      @apply maz-border-success-50 maz-bg-success-50 maz-text-success-700;
-    }
-  }
-
-  &.--contrast {
-    @apply maz-border-contrast maz-bg-contrast maz-text-contrast-foreground;
-
-    &.--outlined {
-      @apply maz-border-contrast maz-bg-transparent maz-text-contrast;
-    }
-
-    &.--pastel {
-      @apply maz-bg-contrast-50 maz-border-contrast-50 maz-text-contrast-foreground;
-    }
-  }
-
-  &.--accent {
-    @apply maz-border-accent maz-bg-accent maz-text-accent-foreground;
-
-    &.--outlined {
-      @apply maz-border-accent maz-bg-transparent maz-text-accent;
-    }
-
-    &.--pastel {
-      @apply maz-border-accent-50 maz-bg-accent-50 maz-text-accent-700;
-    }
+  &.--pastel {
+    background-color: hsl(var(--m-badge-pastel-bg));
+    color: hsl(var(--m-badge-pastel-fg));
+    border-color: hsl(var(--m-badge-pastel-bg));
   }
 
   &.--surface {

--- a/packages/lib/src/components/MazBtn.vue
+++ b/packages/lib/src/components/MazBtn.vue
@@ -166,8 +166,10 @@ const btnStyle = computed<CSSProperties>(() => {
     '--m-btn-bg-active': `var(--maz-${c}-700)`,
     '--m-btn-bd-light': `var(--maz-${c}-200)`,
     '--m-btn-bd-dark': `var(--maz-${c}-700)`,
-    '--m-btn-pastel-bg': `var(--maz-${c}-50)`,
-    '--m-btn-pastel-fg': `var(--maz-${pastelFg})`,
+    ...(pastel && {
+      '--m-btn-pastel-bg': `var(--maz-${c}-50)`,
+      '--m-btn-pastel-fg': `var(--maz-${pastelFg})`,
+    }),
   }
 })
 </script>

--- a/packages/lib/src/components/MazBtn.vue
+++ b/packages/lib/src/components/MazBtn.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { IconComponent } from '@maz-ui/icons'
+import type { CSSProperties } from 'vue'
 import type { MazIconProps } from './MazIcon.vue'
 
 import type { MazColor, MazSize } from './types'
@@ -129,17 +130,11 @@ const component = computed(() => {
   return 'button'
 })
 
-const btnColorClass = computed(() => {
-  if (pastel)
-    return `--${getColor(color)}-pastel`
-  if (outlined)
-    return `--${getColor(color)}-outlined`
-  return `--${getColor(color)}`
-})
+const resolvedColor = computed(() => getColor(color))
+
 const isDisabled = computed(
   () => (loading || disabled) && component.value === 'button',
 )
-const cursorClass = computed(() => (isDisabled.value ? '--cursor-default' : '--cursor-pointer'))
 const btnType = computed(() => (component.value === 'button' ? type : undefined))
 
 const iconSize = computed<MazIconProps['size']>(() => {
@@ -154,6 +149,27 @@ const iconSize = computed<MazIconProps['size']>(() => {
 
   return iconSizeMap[size] || 'lg'
 })
+
+const btnStyle = computed<CSSProperties>(() => {
+  const c = resolvedColor.value
+  const base: Record<string, string> = { '--m-btn-justify': justify }
+  if (c === 'transparent' || c === 'surface')
+    return base
+
+  const pastelFg = c === 'contrast' ? 'contrast-foreground' : `${c}-700`
+
+  return {
+    ...base,
+    '--m-btn-bg': `var(--maz-${c})`,
+    '--m-btn-fg': `var(--maz-${c}-foreground)`,
+    '--m-btn-bg-hover': `var(--maz-${c}-600)`,
+    '--m-btn-bg-active': `var(--maz-${c}-700)`,
+    '--m-btn-bd-light': `var(--maz-${c}-200)`,
+    '--m-btn-bd-dark': `var(--maz-${c}-700)`,
+    '--m-btn-pastel-bg': `var(--maz-${c}-50)`,
+    '--m-btn-pastel-fg': `var(--maz-${pastelFg})`,
+  }
+})
 </script>
 
 <template>
@@ -163,10 +179,11 @@ const iconSize = computed<MazIconProps['size']>(() => {
     class="m-btn m-reset-css"
     :class="[
       `--${size}`,
-      ...[!fab && roundedSize && `--rounded-${roundedSize}`],
-      btnColorClass,
-      cursorClass,
+      `--${resolvedColor}`,
+      !fab && roundedSize && `--rounded-${roundedSize}`,
       {
+        '--outlined': outlined,
+        '--pastel': pastel,
         '--block': block,
         '--fab': fab,
         '--loading': loading,
@@ -176,7 +193,7 @@ const iconSize = computed<MazIconProps['size']>(() => {
         '--has-right-icon': !!rightIcon || hasSlotContent($slots['right-icon']),
       },
     ]"
-    :style="[`--justify: ${justify}`, `--bg-color: var(--maz-${color})`]"
+    :style="btnStyle"
     :type="btnType"
   >
     <!--
@@ -203,7 +220,7 @@ const iconSize = computed<MazIconProps['size']>(() => {
     </slot>
 
     <!--
-      @slot left-icon - The icon to display on the left of the button
+      @slot right-icon - The icon to display on the right of the button
     -->
     <slot name="right-icon">
       <MazIcon v-if="typeof rightIcon === 'string'" :name="rightIcon" :size="iconSize" />
@@ -223,46 +240,151 @@ const iconSize = computed<MazIconProps['size']>(() => {
 
 <style scoped>
 .m-btn {
-  @apply maz-relative maz-items-center maz-gap-2 maz-border maz-border-solid maz-border-transparent maz-text-center maz-align-top maz-text-foreground maz-inline-flex maz-overflow-hidden
-  maz-bg-transparent maz-no-underline maz-transition-all maz-duration-200 maz-ease-in-out maz-py-0.5;
+  @apply maz-relative maz-cursor-pointer maz-items-center maz-gap-2 maz-border maz-border-solid maz-border-transparent maz-bg-transparent maz-py-0.5 maz-text-center maz-align-top maz-text-foreground maz-no-underline maz-transition-all maz-duration-200 maz-ease-in-out maz-inline-flex maz-overflow-hidden;
 
-  justify-content: var(--justify);
+  justify-content: var(--m-btn-justify, center);
+  background-color: hsl(var(--m-btn-bg));
+  color: hsl(var(--m-btn-fg));
 
   & span {
     @apply maz-leading-none;
   }
 
+  &:not(:disabled):hover {
+    background-color: hsl(var(--m-btn-bg-hover));
+  }
+
+  &:not(:disabled):active,
+  &.--active {
+    background-color: hsl(var(--m-btn-bg-active));
+  }
+
   &-loader-container {
     @apply maz-absolute maz-inset-0 maz-flex maz-flex-center;
 
-    background-color: hsl(var(--bg-color) / 100%);
+    background-color: hsl(var(--m-btn-bg));
+    color: hsl(var(--m-btn-fg));
   }
 
-  &.--transparent,
-  &.--transparent-outlined {
-    .m-btn-loader-container {
-      @apply maz-bg-surface;
+  /* Outlined variant */
+  &.--outlined {
+    @apply maz-bg-transparent maz-border-[hsl(var(--m-btn-bd-light))] dark:maz-border-[hsl(var(--m-btn-bd-dark))];
+
+    color: hsl(var(--m-btn-bg));
+
+    &:not(:disabled):hover {
+      background-color: hsl(var(--m-btn-bg) / 10%);
+    }
+
+    &:not(:disabled):active,
+    &.--active {
+      background-color: hsl(var(--m-btn-bg) / 20%);
     }
   }
 
-  &-loader {
-    @apply maz-absolute;
+  /* Pastel variant */
+  &.--pastel {
+    background-color: hsl(var(--m-btn-pastel-bg));
+    color: hsl(var(--m-btn-pastel-fg));
+
+    &:not(:disabled):hover {
+      background-color: hsl(var(--m-btn-bg));
+      color: hsl(var(--m-btn-fg));
+    }
+
+    &:not(:disabled):active,
+    &.--active {
+      background-color: hsl(var(--m-btn-bg-hover));
+      color: hsl(var(--m-btn-fg));
+    }
   }
 
-  &.--cursor-pointer {
-    @apply maz-cursor-pointer;
+  /* Transparent: no theme color, uses surface for hover/active */
+  &.--transparent {
+    @apply maz-bg-transparent maz-text-foreground;
+
+    &:not(:disabled):hover {
+      @apply maz-bg-surface-600/50 dark:maz-bg-surface-400;
+    }
+
+    &.--outlined {
+      @apply maz-border-divider;
+
+      &:not(:disabled):hover {
+        @apply maz-bg-surface-600/50;
+      }
+
+      &:not(:disabled):active,
+      &.--active {
+        @apply maz-bg-surface-600;
+      }
+    }
+
+    &.--pastel {
+      &:not(:disabled):hover {
+        @apply maz-bg-surface-600;
+      }
+
+      &:not(:disabled):active,
+      &.--active {
+        @apply maz-bg-surface-700;
+      }
+    }
+
+    .m-btn-loader-container {
+      @apply maz-bg-surface maz-text-foreground;
+    }
   }
 
-  &.--cursor-default {
-    @apply maz-cursor-default;
+  /* Surface (aka color="background") */
+  &.--surface {
+    @apply maz-bg-surface maz-text-foreground;
+
+    &:not(:disabled):hover {
+      @apply maz-bg-surface-600 dark:maz-bg-surface-400;
+    }
+
+    &:not(:disabled):active,
+    &.--active {
+      @apply maz-bg-surface-700 dark:maz-bg-surface-300;
+    }
+
+    &.--outlined {
+      @apply maz-bg-transparent maz-border-divider;
+
+      &:not(:disabled):hover {
+        @apply maz-bg-surface-600/50;
+      }
+
+      &:not(:disabled):active,
+      &.--active {
+        @apply maz-bg-surface-600;
+      }
+    }
+
+    &.--pastel {
+      @apply maz-bg-surface-600;
+
+      &:not(:disabled):hover {
+        @apply maz-bg-surface-700;
+      }
+
+      &:not(:disabled):active,
+      &.--active {
+        @apply maz-bg-surface-800;
+      }
+    }
+
+    .m-btn-loader-container {
+      @apply maz-text-foreground maz-bg-surface-600 dark:maz-bg-surface-400;
+    }
   }
 
+  /* Rounded */
   &:not(.--rounded-none) {
     @apply maz-rounded;
 
     &.--rounded {
-      @apply maz-rounded-full;
-
       &-sm {
         @apply maz-rounded-sm;
       }
@@ -347,7 +469,6 @@ const iconSize = computed<MazIconProps['size']>(() => {
   }
 
   /* Fab */
-
   &.--fab {
     @apply maz-flex maz-items-center maz-justify-center maz-rounded-full maz-p-1;
 
@@ -379,473 +500,6 @@ const iconSize = computed<MazIconProps['size']>(() => {
   &.--block {
     @apply maz-w-full;
   }
-
-  &.--primary {
-    @apply maz-bg-primary maz-text-primary-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-primary-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-primary-700;
-    }
-  }
-
-  &.--secondary {
-    @apply maz-bg-secondary maz-text-secondary-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-secondary-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-secondary-700;
-    }
-  }
-
-  &.--info {
-    @apply maz-bg-info maz-text-info-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-info-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-info-700;
-    }
-  }
-
-  &.--success {
-    @apply maz-bg-success maz-text-success-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-success-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-success-700;
-    }
-  }
-
-  &.--warning {
-    @apply maz-bg-warning maz-text-warning-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-warning-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-warning-700;
-    }
-  }
-
-  &.--destructive {
-    @apply maz-bg-destructive maz-text-destructive-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-destructive-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-destructive-700;
-    }
-  }
-
-  &.--transparent {
-    @apply maz-bg-transparent;
-
-    &:not(:disabled) {
-      @apply hover:maz-bg-surface-600/50 dark:hover:maz-bg-surface-400;
-    }
-  }
-
-  &.--contrast {
-    @apply maz-bg-contrast maz-text-contrast-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-contrast-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-contrast-700;
-    }
-  }
-
-  &.--accent {
-    @apply maz-bg-accent maz-text-accent-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-accent-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-accent-700;
-    }
-  }
-
-  &.--surface {
-    @apply maz-bg-surface maz-text-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-surface-600 dark:maz-bg-surface-400;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-surface-700 dark:maz-bg-surface-300;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-foreground maz-bg-surface-600 dark:maz-bg-surface-400;
-    }
-  }
-
-  /* OUTLINED */
-
-  &.--primary-outlined {
-    @apply maz-border-primary-200 dark:maz-border-primary-700 maz-text-primary;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-primary/10;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-primary/20;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-primary-foreground;
-    }
-  }
-
-  &.--secondary-outlined {
-    @apply maz-border-secondary-200 dark:maz-border-secondary-700 maz-text-secondary;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-secondary/10;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-secondary/20;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-secondary-foreground;
-    }
-  }
-
-  &.--info-outlined {
-    @apply maz-border-info-200 dark:maz-border-info-700 maz-text-info;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-info/10;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-info/20;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-info-foreground;
-    }
-  }
-
-  &.--success-outlined {
-    @apply maz-border-success-200 dark:maz-border-success-700 maz-text-success;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-success/10;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-success/20;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-success-foreground;
-    }
-  }
-
-  &.--destructive-outlined {
-    @apply maz-border-destructive-200 dark:maz-border-destructive-700 maz-text-destructive;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-destructive/10;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-destructive/20;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-destructive-foreground;
-    }
-  }
-
-  &.--warning-outlined {
-    @apply maz-border-warning-200 dark:maz-border-warning-700 maz-text-warning;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-warning/10;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-warning/20;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-warning-foreground;
-    }
-  }
-
-  &.--contrast-outlined {
-    @apply maz-border-contrast-200 dark:maz-border-contrast-700 maz-text-contrast;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-contrast/10;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-contrast/20;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-contrast-foreground;
-    }
-  }
-
-  &.--accent-outlined {
-    @apply maz-border-accent-200 dark:maz-border-accent-700 maz-text-accent;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-accent/10;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-accent/20;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-accent-foreground;
-    }
-  }
-
-  &.--surface-outlined {
-    @apply maz-border-divider maz-text-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-surface-600/50;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-surface-600;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-foreground;
-    }
-  }
-
-  &.--transparent-outlined {
-    @apply maz-border-divider maz-bg-transparent maz-text-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-surface-600/50;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-surface-600;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-foreground;
-    }
-  }
-
-  /* PASTEL */
-
-  &.--primary-pastel {
-    @apply maz-bg-primary-50 maz-text-primary-700;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-primary maz-text-primary-foreground;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-primary-600 maz-text-primary-foreground;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-primary-foreground;
-    }
-  }
-
-  &.--secondary-pastel {
-    @apply maz-bg-secondary-50 maz-text-secondary-700;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-secondary maz-text-secondary-foreground;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-secondary-600 maz-text-secondary-foreground;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-secondary-foreground;
-    }
-  }
-
-  &.--info-pastel {
-    @apply maz-bg-info-50 maz-text-info-700;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-info maz-text-info-foreground;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-info-600 maz-text-info-foreground;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-info-foreground;
-    }
-  }
-
-  &.--success-pastel {
-    @apply maz-bg-success-50 maz-text-success-700;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-success maz-text-success-foreground;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-success-600 maz-text-success-foreground;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-success-foreground;
-    }
-  }
-
-  &.--destructive-pastel {
-    @apply maz-bg-destructive-50 maz-text-destructive-700;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-destructive maz-text-destructive-foreground;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-destructive-600 maz-text-destructive-foreground;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-destructive-foreground;
-    }
-  }
-
-  &.--warning-pastel {
-    @apply maz-bg-warning-50 maz-text-warning-700;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-warning maz-text-warning-foreground;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-warning-600 maz-text-warning-foreground;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-warning-foreground;
-    }
-  }
-
-  &.--contrast-pastel {
-    @apply maz-bg-contrast-50 maz-text-contrast-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-contrast;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-contrast-600;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-contrast-foreground;
-    }
-  }
-
-  &.--accent-pastel {
-    @apply maz-bg-accent-50 maz-text-accent-700;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-accent maz-text-accent-foreground;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-accent-600 maz-text-accent-foreground;
-    }
-
-    .m-btn-loader-container {
-      @apply maz-text-accent-foreground;
-    }
-  }
-
-  &.--surface-pastel {
-    @apply maz-text-foreground maz-bg-surface-600;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-surface-700;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-surface-800;
-    }
-  }
-
-  &.--transparent-pastel {
-    @apply maz-text-foreground;
-
-    &:not(:disabled):hover {
-      @apply maz-bg-surface-600;
-    }
-
-    &:not(:disabled):active,
-    &.--active {
-      @apply maz-bg-surface-700;
-    }
-  }
-
-  /* DISABLED */
 
   &:disabled:not(.--loading) {
     @apply maz-cursor-not-allowed maz-bg-surface-600 dark:maz-bg-surface-400 maz-text-muted maz-border-surface-600 dark:maz-border-surface-400;

--- a/packages/lib/src/components/MazSlider.vue
+++ b/packages/lib/src/components/MazSlider.vue
@@ -90,6 +90,11 @@ const wrapperStyle = computed(() => {
     paddingTop: labels ? `2.5em` : `1em`,
   }
 })
+const sliderStyle = computed<CSSProperties>(() => {
+  if (color === 'transparent')
+    return {}
+  return { '--m-slider-color': `var(--maz-${color})` } as CSSProperties
+})
 const hasMultipleValues = computed(() => Array.isArray(modelValue))
 
 watch(
@@ -305,7 +310,7 @@ async function handleMousemove(event: MouseEvent | TouchEvent) {
 <template>
   <!-- eslint-disable vuejs-accessibility/mouse-events-have-key-events -->
   <div
-    :style="[wrapperStyle, { fontSize: size }]"
+    :style="[wrapperStyle, sliderStyle, { fontSize: size }]"
     class="m-slider m-reset-css"
     role="button"
     tabindex="-1"
@@ -363,6 +368,7 @@ async function handleMousemove(event: MouseEvent | TouchEvent) {
     @apply maz-relative maz-flex maz-items-center maz-justify-center maz-rounded-full;
 
     height: 0.5em;
+    background-color: hsl(var(--m-slider-color));
   }
 
   &__divider {
@@ -399,9 +405,10 @@ async function handleMousemove(event: MouseEvent | TouchEvent) {
     }
 
     &.active-cursor {
-      transform: scale(1.3);
+      @apply maz-border maz-shadow-lg maz-z-2;
 
-      @apply maz-z-2;
+      transform: scale(1.3);
+      border-color: hsl(var(--m-slider-color));
     }
 
     &::before {
@@ -414,102 +421,6 @@ async function handleMousemove(event: MouseEvent | TouchEvent) {
 
     &:hover {
       @apply maz-bg-surface-200;
-    }
-  }
-
-  &--primary {
-    & .m-slider {
-      &__bar {
-        @apply maz-bg-primary;
-      }
-
-      &__btn.active-cursor {
-        @apply maz-border maz-border-primary maz-shadow-lg;
-      }
-    }
-  }
-
-  &--secondary {
-    & .m-slider {
-      &__bar {
-        @apply maz-bg-secondary;
-      }
-
-      &__btn.active-cursor {
-        @apply maz-border maz-border-secondary maz-shadow-lg;
-      }
-    }
-  }
-
-  &--info {
-    & .m-slider {
-      &__bar {
-        @apply maz-bg-info;
-      }
-
-      &__btn.active-cursor {
-        @apply maz-border maz-border-info maz-shadow-lg;
-      }
-    }
-  }
-
-  &--success {
-    & .m-slider {
-      &__bar {
-        @apply maz-bg-success;
-      }
-
-      &__btn.active-cursor {
-        @apply maz-border maz-border-success maz-shadow-lg;
-      }
-    }
-  }
-
-  &--warning {
-    & .m-slider {
-      &__bar {
-        @apply maz-bg-warning;
-      }
-
-      &__btn.active-cursor {
-        @apply maz-border maz-border-warning maz-shadow-lg;
-      }
-    }
-  }
-
-  &--destructive {
-    & .m-slider {
-      &__bar {
-        @apply maz-bg-destructive;
-      }
-
-      &__btn.active-cursor {
-        @apply maz-border maz-border-destructive maz-shadow-lg;
-      }
-    }
-  }
-
-  &--contrast {
-    & .m-slider {
-      &__bar {
-        @apply maz-bg-contrast;
-      }
-
-      &__btn.active-cursor {
-        @apply maz-border maz-border-contrast maz-shadow-lg;
-      }
-    }
-  }
-
-  &--accent {
-    & .m-slider {
-      &__bar {
-        @apply maz-bg-accent;
-      }
-
-      &__btn.active-cursor {
-        @apply maz-border maz-border-accent maz-shadow-lg;
-      }
     }
   }
 }

--- a/packages/lib/src/components/MazSpinner.vue
+++ b/packages/lib/src/components/MazSpinner.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
+import type { CSSProperties } from 'vue'
 import type { MazColor } from './types'
+import { computed } from 'vue'
 
 export interface MazSpinnerProps {
   /**
@@ -18,6 +20,17 @@ const {
   size = '2em',
   color = 'theme',
 } = defineProps<MazSpinnerProps>()
+
+const spinnerStyle = computed<CSSProperties>(() => {
+  const c = color as string
+  if (!c || c === 'theme')
+    return {}
+  if (c === 'normal')
+    return { color: 'hsl(var(--maz-foreground))' }
+  if (c === 'transparent')
+    return { color: 'white' }
+  return { color: `hsl(var(--maz-${c}))` }
+})
 </script>
 
 <template>
@@ -32,6 +45,7 @@ const {
     xml:space="preserve"
     class="m-spinner m-reset-css"
     :class="`m-spinner--${color}`"
+    :style="spinnerStyle"
   >
     <path
       d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z"
@@ -40,48 +54,8 @@ const {
 </template>
 
 <style scoped>
-  .m-spinner {
+.m-spinner {
   @apply maz-animate-spin maz-fill-current;
   @apply maz-m-0 !important;
-
-  &--normal {
-    @apply maz-text-foreground;
-  }
-
-  &--primary {
-    @apply maz-text-primary;
-  }
-
-  &--secondary {
-    @apply maz-text-secondary;
-  }
-
-  &--accent {
-    @apply maz-text-accent;
-  }
-
-  &--info {
-    @apply maz-text-info;
-  }
-
-  &--warning {
-    @apply maz-text-warning;
-  }
-
-  &--destructive {
-    @apply maz-text-destructive;
-  }
-
-  &--success {
-    @apply maz-text-success;
-  }
-
-  &--transparent {
-    @apply maz-text-white;
-  }
-
-  &--contrast {
-    @apply maz-text-contrast;
-  }
 }
 </style>

--- a/packages/lib/tests/specs/components/MazBtn.spec.ts
+++ b/packages/lib/tests/specs/components/MazBtn.spec.ts
@@ -75,18 +75,11 @@ describe('mazBtn.vue', () => {
     expect(wrapper.attributes('disabled')).toBeDefined()
   })
 
-  it('applies the correct cursor class when disabled', () => {
+  it('applies the loading class when loading prop is true', () => {
     const wrapper = shallowMount(MazBtn, {
-      props: { disabled: true },
+      props: { loading: true },
     })
-    expect(wrapper.classes()).toContain('--cursor-default')
-  })
-
-  it('applies the correct cursor class when not disabled', () => {
-    const wrapper = shallowMount(MazBtn, {
-      props: { disabled: false },
-    })
-    expect(wrapper.classes()).toContain('--cursor-pointer')
+    expect(wrapper.classes()).toContain('--loading')
   })
 
   it('renders default slot content', () => {

--- a/packages/lib/tests/specs/components/MazBtnGroup.spec.ts
+++ b/packages/lib/tests/specs/components/MazBtnGroup.spec.ts
@@ -115,7 +115,8 @@ describe('given MazBtnGroup component', () => {
       await vi.dynamicImportSettled()
 
       const button = wrapper.findComponent(MazBtn)
-      expect(button.classes()).toContain('--primary-outlined')
+      expect(button.classes()).toContain('--primary')
+      expect(button.classes()).toContain('--outlined')
     })
 
     it('then it passes loading prop to button', async () => {
@@ -221,7 +222,8 @@ describe('given MazBtnGroup component', () => {
       await vi.dynamicImportSettled()
 
       const button = wrapper.findComponent(MazBtn)
-      expect(button.classes()).toContain('--success-outlined')
+      expect(button.classes()).toContain('--success')
+      expect(button.classes()).toContain('--outlined')
     })
 
     it('then pastel variant works with group color', async () => {
@@ -236,7 +238,8 @@ describe('given MazBtnGroup component', () => {
       await vi.dynamicImportSettled()
 
       const button = wrapper.findComponent(MazBtn)
-      expect(button.classes()).toContain('--warning-pastel')
+      expect(button.classes()).toContain('--warning')
+      expect(button.classes()).toContain('--pastel')
     })
 
     it('then fab variant works with group size and color', async () => {
@@ -308,7 +311,8 @@ describe('given MazBtnGroup component', () => {
       const buttons = wrapper.findAllComponents(MazBtn)
       expect(buttons).toHaveLength(3)
       buttons.forEach((button) => {
-        expect(button.classes()).toContain('--primary-outlined')
+        expect(button.classes()).toContain('--primary')
+        expect(button.classes()).toContain('--outlined')
       })
     })
 
@@ -347,7 +351,8 @@ describe('given MazBtnGroup component', () => {
       const buttons = wrapper.findAllComponents(MazBtn)
       expect(buttons).toHaveLength(3)
       buttons.forEach((button) => {
-        expect(button.classes()).toContain('--success-pastel')
+        expect(button.classes()).toContain('--success')
+        expect(button.classes()).toContain('--pastel')
       })
     })
 
@@ -365,7 +370,8 @@ describe('given MazBtnGroup component', () => {
 
       const buttons = wrapper.findAllComponents(MazBtn)
       buttons.forEach((button) => {
-        expect(button.classes()).toContain('--info-pastel')
+        expect(button.classes()).toContain('--info')
+        expect(button.classes()).toContain('--pastel')
         expect(button.classes()).toContain('m-button-group__button')
       })
     })
@@ -389,8 +395,8 @@ describe('given MazBtnGroup component', () => {
       expect(buttons).toHaveLength(3)
       buttons.forEach((button) => {
         expect(button.classes()).toContain('--destructive')
-        expect(button.classes()).not.toContain('--destructive-outlined')
-        expect(button.classes()).not.toContain('--destructive-pastel')
+        expect(button.classes()).not.toContain('--outlined')
+        expect(button.classes()).not.toContain('--pastel')
       })
     })
 
@@ -430,8 +436,10 @@ describe('given MazBtnGroup component', () => {
 
       const buttons = wrapper.findAllComponents(MazBtn)
       expect(buttons[0].classes()).toContain('--primary')
-      expect(buttons[1].classes()).toContain('--success-outlined')
-      expect(buttons[2].classes()).toContain('--warning-pastel')
+      expect(buttons[1].classes()).toContain('--success')
+      expect(buttons[1].classes()).toContain('--outlined')
+      expect(buttons[2].classes()).toContain('--warning')
+      expect(buttons[2].classes()).toContain('--pastel')
     })
   })
 

--- a/packages/lib/tests/specs/components/MazFullscreenLoader.spec.ts
+++ b/packages/lib/tests/specs/components/MazFullscreenLoader.spec.ts
@@ -43,7 +43,7 @@ describe('given MazFullscreenLoader.vue component', () => {
     expect(spinner.props('color')).toBe(color)
     expect(spinner.props('size')).toBe(size)
 
-    expect(teleportedContent?.innerHTML).toMatchInlineSnapshot(`"<svg data-v-668667c8="" data-v-01fc091d="" width="2em" height="2em" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 50 50" xml:space="preserve" class="m-spinner m-reset-css m-spinner--secondary"><path data-v-668667c8="" d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z"></path></svg><span data-v-01fc091d="">Contenu personnalisé</span>"`)
+    expect(teleportedContent?.innerHTML).toMatchInlineSnapshot(`"<svg data-v-668667c8="" data-v-01fc091d="" width="2em" height="2em" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 50 50" xml:space="preserve" class="m-spinner m-reset-css m-spinner--secondary" style="color: hsl(var(--maz-secondary));"><path data-v-668667c8="" d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z"></path></svg><span data-v-01fc091d="">Contenu personnalisé</span>"`)
 
     const content = teleportTarget.querySelector('span')
     expect(content?.innerHTML).toBe('Contenu personnalisé')


### PR DESCRIPTION
## Summary

- Refactor `MazBtn.vue` to drive color styling via inline CSS variables (same pattern as `MazAlert.vue`) instead of 24 color-specific CSS blocks (8 colors × 3 variants).
- Style block reduced from **639 → 276 lines (-57%)**, full file from **863 → 516 lines (-40%)**.
- 3 generic variant rules (solid / `--outlined` / `--pastel`) now replace all standard-color blocks; only `transparent` and `surface` keep dedicated overrides (they don't follow the HSL scale pattern).

## Breaking changes (internal CSS classes only — public API unchanged)

- `--{color}-outlined` / `--{color}-pastel` → `--{color}` + `--outlined` / `--pastel` modifiers
- `--cursor-pointer` / `--cursor-default` removed (handled via `:disabled` pseudo + `.--loading` class)
- Inline CSS vars renamed: `--bg-color` → `--m-btn-bg`, `--justify` → `--m-btn-justify`

Props, slots and events are unchanged. Only users overriding these internal classes in external CSS would be impacted.

## Test plan

- [x] `MazBtn.spec.ts` — updated cursor assertions to `.--loading`
- [x] `MazBtnGroup.spec.ts` — updated expectations to compositional classes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` clean (pre-existing warning on `MazPopover.vue` unrelated)
- [x] `pnpm build` succeeds
- [ ] Visual QA on docs app: verify all color/variant combinations (primary/secondary/accent/info/success/warning/destructive/contrast × solid/outlined/pastel) in light + dark mode
- [ ] Visual QA: verify `transparent` and `background` colors (solid/outlined/pastel) in light + dark mode
- [ ] Visual QA: verify disabled, loading, active, fab, block, sizes (xl→mini), rounded variants