### PR TITLE
refactor(maz-ui)!: drop vue-chartjs, lazy chart.js with selective registration

### DIFF
--- a/apps/docs/src/components/maz-chart.md
+++ b/apps/docs/src/components/maz-chart.md
@@ -11,9 +11,13 @@ description: MazChart is a standalone component which generates graphics & chart
 
 Follow the [Chart.JS](https://www.chartjs.org/docs/latest/) documentation to create your own chart.
 
-You can also check the documentation and [examples of vue-chartjs](https://vue-chartjs.org/examples/)
-
 You can use all the plugins of Chart.JS. Follow the examples below.
+
+::: tip Performance
+`MazChart` lazy-loads `chart.js` on mount and registers only the controllers, elements and scales needed for the chart `type` you requested. A `<MazChart type="pie">` won't pull `BarController`, `LineElement` or any other unused module. The chart instance is also held outside Vue's reactivity (`shallowRef` + `markRaw`) — this avoids accidental deep proxying of the underlying chart and the freezes that can come with it on large datasets.
+
+When `data` or `options` change after the initial render, `chart.update()` is called with `'none'` by default so updates don't animate. Pass `update-mode="default"` (or any other Chart.js update mode) to opt back into animations.
+:::
 
 ## Bar chart
 
@@ -318,6 +322,21 @@ const lineChart = {
 
 ## Types
 
-### ChartProps
+`MazChartProps` is generic over the chart type, the data point shape and the label type — it mirrors the same generic signature as `Chart.js` itself:
 
-Follow this link to see the type definitions: [vue-chartjs/src/types.ts](https://github.com/apertureless/vue-chartjs/blob/main/src/types.ts#L12)
+```ts
+interface MazChartProps<
+  T extends ChartType = ChartType,
+  TData = DefaultDataPoint<T>,
+  TLabel = unknown,
+> {
+  type: T
+  data: ChartData<T, TData, TLabel>
+  options?: ChartOptions<T>
+  plugins?: Plugin[]
+  datasetIdKey?: string
+  updateMode?: UpdateMode
+}
+```
+
+For the underlying types, see [chart.js types](https://www.chartjs.org/docs/latest/api/).

--- a/apps/docs/src/guide/migration-v5.md
+++ b/apps/docs/src/guide/migration-v5.md
@@ -21,7 +21,8 @@ Maz-UI is maintained by a single developer. After the v5 stable release, **v4 wi
 6. Replace any **numeric `MazBadge` size** (`size="0.8rem"`, `size="1.2em"`, …) with one of the standardized keywords (`'mini' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`).
 7. **`MazIcon` API simplified** — drop `name`, `path` and `src` props; use a single `icon` prop that accepts a Vue component, a URL/`data:` URI, or a raw SVG string.
 8. Rename **`leftIcon` / `rightIcon`** to **`startIcon` / `endIcon`** (and the matching slots / `--has-*-icon` classes) on `MazBtn`, `MazInput`, `MazLink`, `MazContainer`, `MazSelect`. Same idea for `MazCard`'s `footerAlign` and `MazDrawer`'s `variant` — `'left' | 'right'` becomes `'start' | 'end'`.
-9. That's it for most apps. Everything else is opt-in.
+9. **`MazChart`** drops `vue-chartjs` (lighter bundle, no eager registration of unused chart types). The `updateMode` prop now defaults to `'none'` — pass `update-mode="default"` if you want animated data updates.
+10. That's it for most apps. Everything else is opt-in.
 
 ## Prerequisites
 
@@ -263,7 +264,30 @@ rg "(left|right)-icon|(left|right)Icon|footer-align=\"(left|right)\"|variant=\"(
 
 Falling back to passing `undefined` (or just omitting the prop) opts the icon out, as before.
 
-### 8. `MazBadge` `size` prop now uses `MazSize`
+### 8. `MazChart` no longer depends on `vue-chartjs`
+
+`MazChart` v4 wrapped `vue-chartjs`, eagerly registered every Chart.js controller / element / scale at import time, and updated the chart with the default animation mode on every reactive change. v5 talks to `chart.js` directly, lazy-loads the engine on mount, and only registers the modules required by the chart `type` you requested.
+
+What this means for you:
+
+- The peer dependency on `vue-chartjs` is gone. If you were importing anything from it directly, switch to `chart.js`.
+- The `updateMode` prop now **defaults to `'none'`** (previously `'default'`). Subsequent data / options changes no longer animate by default — this is what makes large dashboards stop freezing on prop updates. The initial render still animates per the chart's `options`. Pass `update-mode="default"` to restore the v4 behavior.
+- The re-exported types (`MazChartData`, `MazChartType`, `MazChartUpdateMode`, `MazChartPlugin`, `MazChartDefaultDataPoint`) are unchanged — they now come from `chart.js` instead of `vue-chartjs` but are otherwise the same. The `ChartProps` link in the v4 docs (which pointed to `vue-chartjs/src/types.ts`) is replaced by the `MazChartProps` interface documented on the [MazChart page](../components/maz-chart.md).
+
+```vue
+<!-- v4 — animated update on every data change -->
+<MazChart :type :data :options />
+
+<!-- v5 — same call, but data updates skip animations by default -->
+<MazChart :type :data :options />
+
+<!-- v5 — restore v4 animated updates -->
+<MazChart :type :data :options update-mode="default" />
+```
+
+If you weren't using `vue-chartjs` directly and were happy with the default animation behavior on every update, you can ignore this — only add `update-mode="default"` where the animation matters.
+
+### 9. `MazBadge` `size` prop now uses `MazSize`
 
 `MazBadge`'s `size` prop used to accept any CSS length string (e.g. `"0.8rem"`, `"1.2em"`). It now follows the same `MazSize` contract as the rest of the library (`MazBtn`, `MazInput`, …): one of `'mini' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'`. The default is `'md'`.
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -202,8 +202,7 @@
     "chart.js": "^4.5.1",
     "dayjs": "^1.11.20",
     "libphonenumber-js": "^1.12.41",
-    "valibot": "^1.3.1",
-    "vue-chartjs": "^5.3.3"
+    "valibot": "^1.3.1"
   },
   "devDependencies": {
     "@maz-ui/eslint-config": "workspace:*",

--- a/packages/lib/src/components/MazChart.vue
+++ b/packages/lib/src/components/MazChart.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
 import type {
+  ChartComponentLike,
   ChartData,
+  Chart as ChartInstance,
   ChartOptions,
   ChartType,
   DefaultDataPoint,
@@ -41,72 +43,120 @@ export interface MazChartProps<T extends ChartType = ChartType, TData = DefaultD
    */
   datasetIdKey?: string
   /**
-   * Update mode
+   * Update mode used when `data` or `options` change after the initial
+   * render. Defaults to `'none'` to skip animations on updates (the
+   * initial render still animates per the chart's `options`).
    * @type UpdateMode
    * @values 'resize', 'reset', 'none', 'hide', 'show', 'default', 'active'
-   * @default 'default'
+   * @default 'none'
    */
   updateMode?: UpdateMode
 }
 </script>
 
 <script lang="ts" setup generic="T extends ChartType, TData = DefaultDataPoint<T>, TLabel = unknown">
-import {
-  ArcElement,
-  BarElement,
-  CategoryScale,
-  Chart,
-  Legend,
-  LinearScale,
-  LineElement,
-  PointElement,
-  Title,
-  Tooltip,
-} from 'chart.js'
-import { defineAsyncComponent } from 'vue'
+import { markRaw, onBeforeUnmount, onMounted, shallowRef, useTemplateRef, watch } from 'vue'
 
 const {
   type,
   data,
-  options = {},
+  options,
   plugins,
   datasetIdKey,
-  updateMode,
+  updateMode = 'none',
 } = defineProps<MazChartProps<T, TData, TLabel>>()
 
-Chart.register(
-  CategoryScale,
-  LinearScale,
-  Title,
-  Tooltip,
-  Legend,
-  BarElement,
-  ArcElement,
-  PointElement,
-  LineElement,
+const canvasRef = useTemplateRef<HTMLCanvasElement>('canvasRef')
+const chartInstance = shallowRef<ChartInstance | null>(null) as { value: ChartInstance | null }
+
+async function loadChartCtor() {
+  const cjs = await import('chart.js')
+  const {
+    Chart,
+    Title,
+    Tooltip,
+    Legend,
+    Filler,
+    BarController,
+    BarElement,
+    LineController,
+    LineElement,
+    PointElement,
+    PieController,
+    DoughnutController,
+    ArcElement,
+    RadarController,
+    PolarAreaController,
+    ScatterController,
+    BubbleController,
+    CategoryScale,
+    LinearScale,
+    RadialLinearScale,
+  } = cjs
+
+  const TYPE_MODULES: Record<ChartType, ReadonlyArray<ChartComponentLike>> = {
+    bar: [BarController, BarElement, CategoryScale, LinearScale],
+    line: [LineController, LineElement, PointElement, CategoryScale, LinearScale],
+    scatter: [ScatterController, LineElement, PointElement, LinearScale],
+    bubble: [BubbleController, PointElement, LinearScale],
+    pie: [PieController, ArcElement],
+    doughnut: [DoughnutController, ArcElement],
+    radar: [RadarController, LineElement, PointElement, RadialLinearScale],
+    polarArea: [PolarAreaController, ArcElement, RadialLinearScale],
+  }
+
+  Chart.register(Title, Tooltip, Legend, Filler, ...TYPE_MODULES[type])
+  return Chart
+}
+
+onMounted(async () => {
+  if (!canvasRef.value)
+    return
+
+  const Chart = await loadChartCtor()
+
+  if (!canvasRef.value)
+    return
+
+  chartInstance.value = markRaw(new Chart(canvasRef.value, {
+    type,
+    data,
+    options,
+    plugins,
+    ...(datasetIdKey ? { datasetIdKey } : {}),
+  } as ConstructorParameters<typeof Chart>[1])) as ChartInstance
+})
+
+watch(
+  () => data,
+  (next) => {
+    const chart = chartInstance.value
+    if (!chart)
+      return
+    chart.data = next as ChartInstance['data']
+    chart.update(updateMode)
+  },
+  { deep: true },
 )
 
-const component = defineAsyncComponent(async () => {
-  const { Bar, Bubble, Doughnut, Line, Pie, PolarArea, Radar, Scatter } = await import(
-    'vue-chartjs',
-  )
+watch(
+  () => options,
+  (next) => {
+    const chart = chartInstance.value
+    if (!chart)
+      return
+    chart.options = (next ?? {}) as ChartInstance['options']
+    chart.update(updateMode)
+  },
+  { deep: true },
+)
 
-  const components = {
-    bar: Bar,
-    line: Line,
-    scatter: Scatter,
-    bubble: Bubble,
-    pie: Pie,
-    doughnut: Doughnut,
-    polarArea: PolarArea,
-    radar: Radar,
-  } as const
-
-  return components[type]
+onBeforeUnmount(() => {
+  chartInstance.value?.destroy()
+  chartInstance.value = null
 })
 </script>
 
 <template>
-  <!-- @vue-expect-error -->
-  <component :is="component" class="m-chart m-reset-css" :data :options :plugins :dataset-id-key :update-mode />
+  <canvas ref="canvasRef" class="m-chart m-reset-css" />
 </template>

--- a/packages/lib/tests/specs/components/MazChart.spec.ts
+++ b/packages/lib/tests/specs/components/MazChart.spec.ts
@@ -1,24 +1,46 @@
 import MazChart from '@components/MazChart.vue'
 import { mount } from '@vue/test-utils'
 
-vi.mock('vue-chartjs', () => {
-  const createMockChart = (name: string) => ({
-    name,
-    props: ['data', 'options', 'plugins', 'datasetIdKey', 'updateMode'],
-    template: `<canvas class="chart-canvas"></canvas>`,
-  })
+const chartInstances: Array<{ data: unknown, options: unknown, update: ReturnType<typeof vi.fn>, destroy: ReturnType<typeof vi.fn> }> = []
+const chartCtorCalls: Array<[unknown, Record<string, unknown>]> = []
 
-  return {
-    Doughnut: createMockChart('Doughnut'),
-    Bar: createMockChart('Bar'),
-    Line: createMockChart('Line'),
-    Pie: createMockChart('Pie'),
-    PolarArea: createMockChart('PolarArea'),
-    Radar: createMockChart('Radar'),
-    Scatter: createMockChart('Scatter'),
-    Bubble: createMockChart('Bubble'),
+class ChartCtor {
+  data: unknown
+  options: unknown
+  update = vi.fn()
+  destroy = vi.fn()
+  static readonly register = vi.fn()
+
+  constructor(canvas: unknown, config: Record<string, unknown>) {
+    this.data = config.data
+    this.options = config.options
+    chartCtorCalls.push([canvas, config])
+    chartInstances.push(this)
   }
-})
+}
+
+vi.mock('chart.js', () => ({
+  Chart: ChartCtor,
+  Title: 'Title',
+  Tooltip: 'Tooltip',
+  Legend: 'Legend',
+  Filler: 'Filler',
+  BarController: 'BarController',
+  BarElement: 'BarElement',
+  LineController: 'LineController',
+  LineElement: 'LineElement',
+  PointElement: 'PointElement',
+  PieController: 'PieController',
+  DoughnutController: 'DoughnutController',
+  ArcElement: 'ArcElement',
+  RadarController: 'RadarController',
+  PolarAreaController: 'PolarAreaController',
+  ScatterController: 'ScatterController',
+  BubbleController: 'BubbleController',
+  CategoryScale: 'CategoryScale',
+  LinearScale: 'LinearScale',
+  RadialLinearScale: 'RadialLinearScale',
+}))
 
 const pieChart = {
   type: 'doughnut',
@@ -34,7 +56,13 @@ const pieChart = {
 }
 
 describe('mazChart', () => {
-  it('should render the chart component with correct props', async () => {
+  beforeEach(() => {
+    chartInstances.length = 0
+    chartCtorCalls.length = 0
+    ChartCtor.register.mockClear()
+  })
+
+  it('renders a canvas with the m-chart class', () => {
     const wrapper = mount(MazChart, {
       props: {
         data: pieChart.data,
@@ -42,13 +70,85 @@ describe('mazChart', () => {
       },
     })
 
-    expect(wrapper.exists()).toBe(true)
-    expect(wrapper.props('data')).toEqual(pieChart.data)
-    expect(wrapper.props('type')).toBe(pieChart.type)
+    const canvas = wrapper.find('canvas')
+    expect(canvas.exists()).toBe(true)
+    expect(canvas.classes()).toContain('m-chart')
+  })
 
-    // Test that the async component starts loading
-    await new Promise(resolve => setTimeout(resolve, 100))
+  it('lazy-loads chart.js, registers only the modules needed for the type, and instantiates the chart on mount', async () => {
+    const wrapper = mount(MazChart, {
+      props: {
+        data: pieChart.data,
+        type: pieChart.type as any,
+      },
+    })
 
-    expect(wrapper.html()).toContain('chart-canvas')
+    await vi.dynamicImportSettled()
+
+    expect(ChartCtor.register).toHaveBeenCalledTimes(1)
+    const registered = ChartCtor.register.mock.calls[0]
+    expect(registered).toContain('DoughnutController')
+    expect(registered).toContain('ArcElement')
+    expect(registered).not.toContain('BarController')
+    expect(registered).not.toContain('CategoryScale')
+
+    expect(chartCtorCalls).toHaveLength(1)
+    const [canvas, config] = chartCtorCalls[0]
+    expect(canvas).toBe(wrapper.find('canvas').element)
+    expect(config.type).toBe('doughnut')
+    expect(config.data).toEqual(pieChart.data)
+  })
+
+  it('updates the chart when data changes and uses the configured updateMode', async () => {
+    const wrapper = mount(MazChart, {
+      props: {
+        data: pieChart.data,
+        type: pieChart.type as any,
+        updateMode: 'reset',
+      },
+    })
+
+    await vi.dynamicImportSettled()
+    const instance = chartInstances[0]
+
+    await wrapper.setProps({
+      data: { ...pieChart.data, datasets: [{ ...pieChart.data.datasets[0], data: [10, 20, 30] }] },
+    })
+
+    expect(instance.update).toHaveBeenCalledWith('reset')
+  })
+
+  it('defaults updateMode to "none" so data changes do not animate', async () => {
+    const wrapper = mount(MazChart, {
+      props: {
+        data: pieChart.data,
+        type: pieChart.type as any,
+      },
+    })
+
+    await vi.dynamicImportSettled()
+    const instance = chartInstances[0]
+
+    await wrapper.setProps({
+      data: { ...pieChart.data, datasets: [{ ...pieChart.data.datasets[0], data: [1, 2, 3] }] },
+    })
+
+    expect(instance.update).toHaveBeenCalledWith('none')
+  })
+
+  it('destroys the chart on unmount', async () => {
+    const wrapper = mount(MazChart, {
+      props: {
+        data: pieChart.data,
+        type: pieChart.type as any,
+      },
+    })
+
+    await vi.dynamicImportSettled()
+    const instance = chartInstances[0]
+
+    wrapper.unmount()
+
+    expect(instance.destroy).toHaveBeenCalledTimes(1)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,9 +371,6 @@ importers:
       vue:
         specifier: '>=3.5.0 <4.0.0'
         version: 3.5.32(typescript@6.0.2)
-      vue-chartjs:
-        specifier: ^5.3.3
-        version: 5.3.3(chart.js@4.5.1)(vue@3.5.32(typescript@6.0.2))
     devDependencies:
       '@maz-ui/eslint-config':
         specifier: workspace:*
@@ -10561,12 +10558,6 @@ packages:
 
   vue-bundle-renderer@2.2.0:
     resolution: {integrity: sha512-sz/0WEdYH1KfaOm0XaBmRZOWgYTEvUDt6yPYaUzl4E52qzgWLlknaPPTTZmp6benaPTlQAI/hN1x3tAzZygycg==}
-
-  vue-chartjs@5.3.3:
-    resolution: {integrity: sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==}
-    peerDependencies:
-      chart.js: ^4.1.1
-      vue: ^3.0.0-0 || ^2.7.0
 
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
@@ -21690,11 +21681,6 @@ snapshots:
   vue-bundle-renderer@2.2.0:
     dependencies:
       ufo: 1.6.3
-
-  vue-chartjs@5.3.3(chart.js@4.5.1)(vue@3.5.32(typescript@6.0.2)):
-    dependencies:
-      chart.js: 4.5.1
-      vue: 3.5.32(typescript@6.0.2)
 
   vue-component-type-helpers@2.2.12: {}
 


### PR DESCRIPTION
## Summary

Replaces the `vue-chartjs` wrapper inside `MazChart` with a thin direct binding to `chart.js`. Goal: fix the production crashes / freezes reported on dashboards with large datasets and cut the chart bundle paid by every consumer.

## What changed

### Bundle / perf

- **Lazy load** — `chart.js` is dynamically imported inside `onMounted`. Nothing related to charts runs at import time anymore; the ~150KB engine is only paid when a `<MazChart>` actually mounts.
- **Selective registration** — only the controllers, elements and scales required by the requested `type` are registered. `<MazChart type=\"pie\">` no longer pulls `BarController`, `LineElement`, `CategoryScale`, etc. Mapping kept in a small `TYPE_MODULES` table inside the component.
- **`shallowRef` + `markRaw`** on the Chart.js instance — Vue no longer deep-proxies Chart.js internals (this was the main source of the freezes on large datasets).
- **`updateMode` default = `'none'`** (was `'default'`). Subsequent data/options updates don't animate by default — large dashboards stop freezing on prop updates. The initial render still animates per the chart's `options`. Pass `update-mode=\"default\"` to opt back into v4 behavior.

### Reliability

- **Deterministic cleanup** — `chart.destroy()` runs in `onBeforeUnmount`. The vue-chartjs unmount race condition (update fires after destroy, sometimes crashes) is gone.

### Why not `chart.js/auto`?

`chart.js/auto` is the opposite of what we need — it registers every controller / element / scale at import time, putting us right back where v4 was bundle-wise. We keep the selective approach.

## Public API

Unchanged. Same props (`type`, `data`, `options`, `plugins`, `datasetIdKey`, `updateMode`). Type re-exports (`MazChartData`, `MazChartType`, `MazChartUpdateMode`, `MazChartPlugin`, `MazChartDefaultDataPoint`) now come from `chart.js` instead of `vue-chartjs` but are structurally identical.

## Breaking changes

- Drops `vue-chartjs` peer dependency. If any consumer imported from it directly, they should switch to `chart.js`.
- `updateMode` default flipped to `'none'`. Documented in migration-v5.

## Test plan

- [x] 5 unit tests (canvas render, lazy + selective registration, update on data change with explicit & default updateMode, destroy on unmount).
- [x] Full lib suite green (2870 / 2870).
- [x] `pnpm typecheck` green.
- [x] `pnpm lint` green.
- [ ] Manual smoke on the docs site (3 chart examples) — to do before merging.

## Docs

- `apps/docs/src/components/maz-chart.md` — vue-chartjs link removed; perf tip added; types section now documents the local `MazChartProps` interface and links to chart.js types.
- `apps/docs/src/guide/migration-v5.md` — new section #4 dedicated to MazChart, TL;DR updated.