### PR TITLE
feat(@maz-ui/eslint-config): add maz/tailwind-no-arbitrary-px rule

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -104,17 +104,17 @@ jobs:
           fail_ci_if_error: false
           verbose: false
 
-      - name: Upload coverage to Codecov (forms)
-        if: always()
-        # && github.event.pull_request.user.login != 'dependabot[bot]'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/forms/coverage/lcov.info
-          flags: forms
-          name: forms-coverage
-          fail_ci_if_error: false
-          verbose: false
+      # - name: Upload coverage to Codecov (forms)
+      #   if: always()
+      #   # && github.event.pull_request.user.login != 'dependabot[bot]'
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: packages/forms/coverage/lcov.info
+      #     flags: forms
+      #     name: forms-coverage
+      #     fail_ci_if_error: false
+      #     verbose: false
 
       - name: Upload coverage to Codecov (node)
         if: always()
@@ -137,5 +137,29 @@ jobs:
           files: packages/nuxt/coverage/lcov.info
           flags: nuxt
           name: nuxt-coverage
+          fail_ci_if_error: false
+          verbose: false
+
+      - name: Upload coverage to Codecov (eslint-config)
+        if: always()
+        # && github.event.pull_request.user.login != 'dependabot[bot]'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/eslint-config/coverage/lcov.info
+          flags: eslint-config
+          name: eslint-config-coverage
+          fail_ci_if_error: false
+          verbose: false
+
+      - name: Upload coverage to Codecov (stylelint-config)
+        if: always()
+        # && github.event.pull_request.user.login != 'dependabot[bot]'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/stylelint-config/coverage/lcov.info
+          flags: stylelint-config
+          name: stylelint-config-coverage
           fail_ci_if_error: false
           verbose: false

--- a/apps/docs/src/ecosystem/eslint-config.md
+++ b/apps/docs/src/ecosystem/eslint-config.md
@@ -114,6 +114,8 @@ defineConfig({
     detectComponentClasses: true,
     // Monorepo: directory used to resolve `tailwindcss` and the config file.
     cwd: 'apps/web',
+    // Custom `maz/tailwind-no-arbitrary-px` rule — see "Custom rules" below.
+    noArbitraryPx: true,
   },
 })
 ```
@@ -135,12 +137,98 @@ defineConfig({
 
 The plugin recognizes the most common class-name utilities out of the box (`clsx`, `cn`, `tw-merge`, `cva`, `tv`, …); see the [plugin docs](https://github.com/schoero/eslint-plugin-better-tailwindcss) for the full list and how to register your own.
 
+## Custom rules
+
+`@maz-ui/eslint-config` ships its own ESLint plugin under the **`maz/*`** namespace. Rules are grouped by category — `maz/tailwind-*` today, with room for `maz/js-*` and others as they get added.
+
+### `maz/tailwind-no-arbitrary-px`
+
+Forbids `px` units inside Tailwind arbitrary value classes (`w-[16px]`, `m-[-16px]`, `[gap:24px]`, …) and **autofixes** them to `rem` (or `em`) using your project's root font-size. Whitespace inside brackets (e.g. `[up to 100px]`) is left alone, so plain prose is never rewritten by accident.
+
+::: info Registered only when `tailwindcss` is enabled
+The `maz` plugin and the `maz/tailwind-*` rules are only added to the flat-config when `tailwindcss` is set to anything other than `false`. With `tailwindcss: false` *(default)*, neither the plugin nor the rule appear in the resolved config — keeping the preset zero-cost for non-Tailwind projects. To use the rule without opting into the full Tailwind preset, register `mazPlugin` manually (see [Use the plugin directly](#use-the-plugin-directly)).
+:::
+
+When `tailwindcss` is on, the rule is enabled with defaults. You can tune it two ways:
+
+**Standard ESLint override** *(idiomatic, max control)*
+
+```ts
+defineConfig({
+  tailwindcss: 'recommended',
+  rules: {
+    'maz/tailwind-no-arbitrary-px': ['error', { baseFontSize: 10, unit: 'em' }],
+  },
+})
+```
+
+User `rules` overrides are applied in a *trailing* flat-config block, so they win over the defaults wired in by `tailwindcssConfigs`.
+
+**Ergonomic shortcut** *(set defaults via `tailwindcss.noArbitraryPx`)*
+
+```ts
+defineConfig({
+  tailwindcss: {
+    preset: 'recommended',
+    noArbitraryPx: {
+      baseFontSize: 16, // default — divide px by this to get rem
+      unit: 'rem', // default — output unit ('rem' | 'em')
+      severity: 'error', // default — 'off' | 'warn' | 'error'
+    },
+  },
+})
+```
+
+| `noArbitraryPx` value              | Behavior                                            |
+| ---------------------------------- | --------------------------------------------------- |
+| `true` *(default)*                 | Enabled with defaults (`baseFontSize: 16`, `rem`).  |
+| `false`                            | Disabled.                                           |
+| `{ baseFontSize, unit, severity }` | Override any subset of the defaults.                |
+
+If both are set, the standard `rules` override wins (it's the last block applied).
+
+What the autofix does (with `baseFontSize: 16`):
+
+| Before                  | After                    |
+| ----------------------- | ------------------------ |
+| `w-[16px]`              | `w-[1rem]`               |
+| `m-[-16px]`             | `m-[-1rem]`              |
+| `tracking-[.5px]`       | `tracking-[0.03125rem]`  |
+| `p-[16px_8px]`          | `p-[1rem_0.5rem]`        |
+| `[gap:24px]`            | `[gap:1.5rem]`           |
+| `w-[calc(100%-16px)]`   | `w-[calc(100%-1rem)]`    |
+| `md:hover:w-[16px]`     | `md:hover:w-[1rem]`      |
+
+The rule fires on:
+
+- JSX `className` strings and template literals
+- Vue SFC static `class="…"` attributes (via `vue-eslint-parser`)
+- Vue dynamic `:class` bindings, including string literals inside arrays / objects
+- Function-call arguments and tagged template literals (`clsx`, `cn`, `cva`, `tw`, …)
+
+### Use the plugin directly
+
+If you don't want the full Tailwind preset (or just prefer wiring rules yourself), import `mazPlugin` and register it in your own flat-config block. This is also the way to use `maz/tailwind-*` rules **without** enabling `tailwindcss` in `defineConfig`:
+
+```ts
+import { mazPlugin } from '@maz-ui/eslint-config'
+
+export default [{
+  files: ['**/*.{ts,tsx,vue}'],
+  plugins: { maz: mazPlugin },
+  rules: {
+    'maz/tailwind-no-arbitrary-px': ['error', { baseFontSize: 16, unit: 'rem' }],
+  },
+}]
+```
+
 ## What it includes
 
 - **Antfu base** — TypeScript-aware rules, Stylistic formatting, modern import order.
 - **SonarJS** — code quality and complexity heuristics, with a relaxed set for `*.spec.ts` / `*.test.ts`.
 - **Vue rules** (when Vue/Nuxt is detected) — block-tag order, naming conventions, template a11y.
 - **Tailwind plugin** (opt-in) — class ordering, duplicate / deprecated / unknown / conflicting class detection — see [Tailwind support](#tailwind-support).
+- **`maz/*` custom rules** — namespaced ESLint plugin shipped with the preset; see [Custom rules](#custom-rules).
 - **Markdown** — prose linting baseline.
 - **vueAccessibility** (opt-in) — `eslint-plugin-vuejs-accessibility` rules with the AudioWorklet globals fix.
 
@@ -151,6 +239,7 @@ The plugin recognizes the most common class-name utilities out of the box (`clsx
 ```ts
 import {
   baseRules,
+  mazPlugin,
   sonarjsRules,
   tailwindcssConfigs,
   vueRules,
@@ -158,14 +247,19 @@ import {
 
 export default [
   {
+    plugins: { maz: mazPlugin },
     rules: {
       ...baseRules(true), // production = true → no-console: 'error'
       ...sonarjsRules,
       ...vueRules,
+      'maz/tailwind-no-arbitrary-px': 'error',
     },
   },
   // Drop in just the Tailwind block, with whatever preset and settings you want.
-  ...tailwindcssConfigs('stylistic', { entryPoint: 'src/main.css' }),
+  ...tailwindcssConfigs('stylistic', {
+    entryPoint: 'src/main.css',
+    noArbitraryPx: { unit: 'em' },
+  }),
 ]
 ```
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -58,13 +58,13 @@ coverage:
         paths:
           - packages/mcp/
 
-      icons:
-        target: 70%
-        threshold: 1%
-        flags:
-          - icons
-        paths:
-          - packages/icons/
+      # icons:
+      #   target: 70%
+      #   threshold: 1%
+      #   flags:
+      #     - icons
+      #   paths:
+      #     - packages/icons/
 
       translations:
         target: 90%
@@ -98,13 +98,21 @@ coverage:
         paths:
           - packages/themes/
 
-      maz-cli:
+      eslint-config:
         target: 70%
         threshold: 1%
         flags:
-          - maz-cli
+          - eslint-config
         paths:
-          - packages/maz-cli/
+          - packages/eslint-config/
+
+      stylelint-config:
+        target: 70%
+        threshold: 1%
+        flags:
+          - stylelint-config
+        paths:
+          - packages/stylelint-config/
 
     # Patch-level coverage (new code in PR)
     patch:
@@ -181,6 +189,16 @@ flags:
       - packages/maz-cli/
     carryforward: false
 
+  eslint-config:
+    paths:
+      - packages/eslint-config/
+    carryforward: false
+
+  stylelint-config:
+    paths:
+      - packages/stylelint-config/
+    carryforward: false
+
 # Ignore paths
 ignore:
   - '**/*.test.ts'
@@ -243,8 +261,3 @@ component_management:
       name: Themes Package
       paths:
         - packages/themes/**
-
-    - component_id: maz-cli
-      name: Maz CLI
-      paths:
-        - packages/maz-cli/**

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -7,6 +7,7 @@ Reusable ESLint configuration for JavaScript/TypeScript projects, built on top o
 - 🚀 **Based on @antfu/eslint-config** — modern, performant, flat-config first
 - 🛡️ **TypeScript-first** — strict mode, sensible defaults
 - 🎨 **Tailwind CSS v3 + v4** — via [`eslint-plugin-better-tailwindcss`](https://github.com/schoero/eslint-plugin-better-tailwindcss) (compat ESLint 7→10, both Tailwind versions)
+- 🧩 **Custom `maz/` rules** — ships its own ESLint plugin namespaced `maz/*` (see [Custom rules](#custom-rules))
 - 🔍 **SonarJS** — code quality / cognitive complexity
 - ♿ **Vue accessibility** — opt-in `eslint-plugin-vuejs-accessibility`
 - 📐 **Formatters** — Prettier-style formatting via `eslint-plugin-format`
@@ -96,12 +97,90 @@ defineConfig({
     // Tailwind v3 instead:
     // tailwindConfig: 'tailwind.config.ts',
     detectComponentClasses: true,
+    // Custom `maz/tailwind-no-arbitrary-px` rule — see "Custom rules" below.
+    noArbitraryPx: true,
   },
 })
 ```
 
 > [!IMPORTANT]
 > The plugin's `no-unknown-classes` rule needs to know about your Tailwind setup (prefix, custom utilities, theme tokens). Without `entryPoint` (v4) or `tailwindConfig` (v3), it falls back to the default Tailwind config and will flood with false positives in projects that customize either. **Pass the path explicitly** if your Tailwind setup is non-standard.
+
+## Custom rules
+
+This preset ships its own ESLint plugin under the `maz/*` namespace. Rules are organized by category — `maz/tailwind-*` for Tailwind-specific rules, ready for `maz/js-*` and others as they get added.
+
+### `maz/tailwind-no-arbitrary-px`
+
+Forbids `px` units inside Tailwind arbitrary value classes (`w-[16px]`, `m-[-16px]`, `[gap:24px]`, …) and **autofixes** them to `rem` (or `em`) using the configured root font-size. Whitespace inside brackets (e.g. `[up to 100px]`) is left alone so plain prose is never rewritten.
+
+> [!NOTE]
+> The rule and the `maz` plugin are only registered when `tailwindcss` is enabled (any value other than `false`). With `tailwindcss: false` _(default)_ neither the plugin nor the rule appear in the final flat-config. To use the rule in a project that doesn't opt into the full Tailwind preset, register it manually (see [Use the plugin directly](#use-the-plugin-directly)).
+
+When `tailwindcss` is on, the rule is enabled with defaults. You can tune it either way:
+
+**Standard ESLint override** _(idiomatic, max control)_
+
+```js
+defineConfig({
+  tailwindcss: 'recommended',
+  rules: {
+    'maz/tailwind-no-arbitrary-px': ['error', { baseFontSize: 10, unit: 'em' }],
+  },
+})
+```
+
+User `rules` overrides are applied in a _trailing_ block, so they win over the rule's defaults wired in by `tailwindcssConfigs`.
+
+**Ergonomic shortcut** _(set the defaults via `tailwindcss.noArbitraryPx`)_
+
+```js
+defineConfig({
+  tailwindcss: {
+    preset: 'recommended',
+    noArbitraryPx: {
+      baseFontSize: 16, // default — convert px / 16 → rem
+      unit: 'rem', // default — target unit ('rem' | 'em')
+      severity: 'error', // default — 'off' | 'warn' | 'error'
+    },
+  },
+})
+```
+
+| `noArbitraryPx` value              | Behavior                                           |
+| ---------------------------------- | -------------------------------------------------- |
+| `true` _(default)_                 | Enabled with defaults (`baseFontSize: 16`, `rem`). |
+| `false`                            | Disabled.                                          |
+| `{ baseFontSize, unit, severity }` | Override any subset of the defaults.               |
+
+If both are set, the standard `rules` override wins (last block applied).
+
+Examples after autofix (with `baseFontSize: 16`):
+
+| Before                | After                   |
+| --------------------- | ----------------------- |
+| `w-[16px]`            | `w-[1rem]`              |
+| `m-[-16px]`           | `m-[-1rem]`             |
+| `tracking-[.5px]`     | `tracking-[0.03125rem]` |
+| `p-[16px_8px]`        | `p-[1rem_0.5rem]`       |
+| `[gap:24px]`          | `[gap:1.5rem]`          |
+| `w-[calc(100%-16px)]` | `w-[calc(100%-1rem)]`   |
+
+### Use the plugin directly
+
+If you don't want the full Tailwind preset (or just prefer wiring rules yourself), import `mazPlugin` and register it in your own flat-config block. This is also the way to use `maz/tailwind-*` rules without enabling `tailwindcss` in `defineConfig`:
+
+```js
+import { mazPlugin } from '@maz-ui/eslint-config'
+
+export default [{
+  files: ['**/*.{ts,tsx,vue}'],
+  plugins: { maz: mazPlugin },
+  rules: {
+    'maz/tailwind-no-arbitrary-px': ['error', { baseFontSize: 16 }],
+  },
+}]
+```
 
 ## Advanced
 
@@ -110,6 +189,7 @@ defineConfig({
 ```js
 import {
   baseRules,
+  mazPlugin,
   sonarjsRules,
   tailwindcssConfigs,
   vueRules,
@@ -117,13 +197,18 @@ import {
 
 export default [
   {
+    plugins: { maz: mazPlugin },
     rules: {
       ...baseRules(true), // production = true
       ...sonarjsRules,
       ...vueRules,
+      'maz/tailwind-no-arbitrary-px': 'error',
     },
   },
-  ...tailwindcssConfigs('stylistic', { entryPoint: 'src/main.css' }),
+  ...tailwindcssConfigs('stylistic', {
+    entryPoint: 'src/main.css',
+    noArbitraryPx: { unit: 'em' },
+  }),
 ]
 ```
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -44,7 +44,10 @@
     "dev": "unbuild --stub",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "lint": "cross-env NODE_ENV=production eslint .",
-    "lint:fix": "pnpm lint --fix"
+    "lint:fix": "pnpm lint --fix",
+    "test:unit": "vitest run",
+    "test:unit:coverage": "vitest run --coverage",
+    "test:unit:watch": "vitest watch"
   },
   "peerDependencies": {
     "eslint": ">=9.0.0 <11.0.0"

--- a/packages/eslint-config/src/__tests__/index.test.ts
+++ b/packages/eslint-config/src/__tests__/index.test.ts
@@ -1,0 +1,381 @@
+import { readFileSync } from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `defineConfig` calls `antfu()` which writes a startup banner to stderr.
+// Silence the streams across the whole suite to keep the test output clean.
+let stdoutSpy: ReturnType<typeof vi.spyOn>
+let stderrSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+})
+
+afterEach(() => {
+  stdoutSpy.mockRestore()
+  stderrSpy.mockRestore()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+// `getPackageJson()` inside the preset calls `readFileSync` from `node:fs`.
+// We mock the module so resolveVue's auto-detect branch can be steered.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+  }
+})
+
+const mockedReadFileSync = vi.mocked(readFileSync)
+
+function stubPackageJson(json: object | 'throw'): void {
+  mockedReadFileSync.mockImplementation(((path: any, ...rest: any[]) => {
+    if (typeof path === 'string' && path.endsWith('package.json')) {
+      if (json === 'throw')
+        throw new Error('ENOENT')
+      return JSON.stringify(json)
+    }
+    return (vi.importActual('node:fs') as any).readFileSync(path, ...rest)
+  }) as any)
+}
+
+async function loadDefineConfig() {
+  // Re-import the module after mocks are in place.
+  vi.resetModules()
+  return (await import('../index')).defineConfig
+}
+
+describe('defineConfig', () => {
+  it('returns a flat-config array with no options', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+    expect(config.length).toBeGreaterThan(0)
+  })
+
+  it('honors explicit `env: production` (no-console becomes error)', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ env: 'production', logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('honors explicit `env: development`', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ env: 'development', logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('reads `env` from NODE_ENV when not provided', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('falls back to `production` when neither opts.env nor NODE_ENV is set', async () => {
+    vi.stubEnv('NODE_ENV', '')
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('auto-detects Vue from package.json', async () => {
+    stubPackageJson({ dependencies: { vue: '^3.0.0' } })
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('auto-detects Nuxt from devDependencies', async () => {
+    stubPackageJson({ devDependencies: { nuxt: '^3.0.0' } })
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('checks peerDependencies for auto-detection', async () => {
+    stubPackageJson({ peerDependencies: { vue: '^3.0.0' } })
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('tolerates a missing / unreadable package.json', async () => {
+    stubPackageJson('throw')
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('honors explicit `vue: true`', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ vue: true, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('honors explicit `vue: false`', async () => {
+    stubPackageJson({ dependencies: { vue: '^3.0.0' } })
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ vue: false, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('disables sonarjs when option is false', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ sonarjs: false, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('enables vueAccessibility', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ vueAccessibility: true, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('accepts tailwindcss = true', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ tailwindcss: true, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('accepts tailwindcss = false', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ tailwindcss: false, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('accepts tailwindcss as preset string', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ tailwindcss: 'stylistic', logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('accepts tailwindcss as settings object with preset', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({
+      tailwindcss: { preset: 'correctness', entryPoint: 'src/main.css' },
+      logLevel: 'silent',
+    })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('accepts tailwindcss as settings object without preset (defaults to recommended)', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({
+      tailwindcss: { entryPoint: 'src/main.css' },
+      logLevel: 'silent',
+    })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('merges custom rules', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({
+      rules: { 'no-console': 'error' },
+      logLevel: 'silent',
+    })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('lets `rules` override a rule set by an internal config block (e.g. tailwindcss)', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({
+      tailwindcss: 'recommended',
+      rules: {
+        'maz/tailwind-no-arbitrary-px': ['error', { baseFontSize: 10, unit: 'em' }],
+      },
+      logLevel: 'silent',
+    })
+
+    // Walk the produced flat-config from the end: the *last* block setting
+    // `maz/tailwind-no-arbitrary-px` is the one ESLint will actually apply.
+    const ruleEntries = (config as Array<{ rules?: Record<string, unknown> }>)
+      .map(block => block?.rules?.['maz/tailwind-no-arbitrary-px'])
+      .filter(Boolean)
+
+    expect(ruleEntries.at(-1)).toEqual(['error', { baseFontSize: 10, unit: 'em' }])
+  })
+
+  it('keeps internal noArbitraryPx defaults when the user does not override them', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({
+      tailwindcss: 'recommended',
+      logLevel: 'silent',
+    })
+
+    const ruleEntries = (config as Array<{ rules?: Record<string, unknown> }>)
+      .map(block => block?.rules?.['maz/tailwind-no-arbitrary-px'])
+      .filter(Boolean)
+
+    expect(ruleEntries.at(-1)).toEqual(['error', { baseFontSize: 16, unit: 'rem' }])
+  })
+
+  it('does not register the maz/tailwind-* rule when tailwindcss is disabled', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ tailwindcss: false, logLevel: 'silent' })
+
+    const blocks = config as Array<{
+      rules?: Record<string, unknown>
+      plugins?: Record<string, unknown>
+    }>
+
+    const hasRule = blocks.some(block => block?.rules?.['maz/tailwind-no-arbitrary-px'] !== undefined)
+    const hasMazPlugin = blocks.some(block => block?.plugins?.maz !== undefined)
+    expect(hasRule).toBe(false)
+    expect(hasMazPlugin).toBe(false)
+  })
+
+  it('does not register the maz/tailwind-* rule by default (tailwindcss omitted)', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ logLevel: 'silent' })
+
+    const blocks = config as Array<{ rules?: Record<string, unknown> }>
+    const hasRule = blocks.some(block => block?.rules?.['maz/tailwind-no-arbitrary-px'] !== undefined)
+    expect(hasRule).toBe(false)
+  })
+
+  it('appends extra user flat-config blocks', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig(
+      { logLevel: 'silent' },
+      { files: ['**/*.legacy.ts'], rules: { 'no-console': 'off' } },
+    )
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('respects custom ignores', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({
+      ignores: ['custom-dist/**'],
+      logLevel: 'silent',
+    })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('uses default logLevel when no value is provided on a TTY', async () => {
+    stubPackageJson({})
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig()
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('uses silent logLevel when stdout is not a TTY', async () => {
+    stubPackageJson({})
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true })
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig()
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('exposes the verbose log level path', async () => {
+    stubPackageJson({})
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({
+      vue: true,
+      vueAccessibility: true,
+      tailwindcss: 'recommended',
+      rules: { 'no-console': 'error' },
+      logLevel: 'verbose',
+    }, { files: ['**/*.x.ts'], rules: {} })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('strips the buggy `AudioWorkletGlobalScope ` (trailing space) globals key from vue-a11y configs', async () => {
+    stubPackageJson({})
+    // Stand in for the plugin's flat/recommended config, including the
+    // trailing-space typo from vue-a11y issue #1269.
+    vi.doMock('eslint-plugin-vuejs-accessibility', () => ({
+      default: {
+        configs: {
+          'flat/recommended': [
+            {
+              languageOptions: {
+                globals: {
+                  'AudioWorkletGlobalScope ': 'readonly',
+                  'window': 'readonly',
+                },
+              },
+              rules: {},
+            },
+          ],
+        },
+      },
+    }))
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ vueAccessibility: true, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('passes through vue-a11y configs that have no languageOptions.globals', async () => {
+    stubPackageJson({})
+    vi.doMock('eslint-plugin-vuejs-accessibility', () => ({
+      default: {
+        configs: {
+          'flat/recommended': [
+            // Plain config with no languageOptions at all — falls through
+            // to the early `return config` branch.
+            { rules: {} },
+          ],
+        },
+      },
+    }))
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ vueAccessibility: true, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('treats an explicit `tailwindcss: undefined` as the default (source = default)', async () => {
+    stubPackageJson({})
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    const defineConfig = await loadDefineConfig()
+    // Logging must be on (non-silent) so the resolution box runs through
+    // `formatSourceTag('default')`. Combined with `tailwindcss: undefined`,
+    // this also exercises the `option === undefined` branch in
+    // `resolveTailwindcss`.
+    const config = await defineConfig({
+      tailwindcss: undefined,
+      logLevel: 'default',
+    })
+    expect(Array.isArray(config)).toBe(true)
+  })
+
+  it('normalizes a non-array vue-a11y flat/recommended config', async () => {
+    stubPackageJson({})
+    vi.doMock('eslint-plugin-vuejs-accessibility', () => ({
+      default: {
+        configs: {
+          // Single object instead of an array — exercises the `Array.isArray`
+          // normalization branch.
+          'flat/recommended': { rules: {} },
+        },
+      },
+    }))
+    const defineConfig = await loadDefineConfig()
+    const config = await defineConfig({ vueAccessibility: true, logLevel: 'silent' })
+    expect(Array.isArray(config)).toBe(true)
+  })
+})

--- a/packages/eslint-config/src/__tests__/plugin.test.ts
+++ b/packages/eslint-config/src/__tests__/plugin.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { mazPlugin } from '../plugin'
+import { rules } from '../rules'
+
+describe('mazPlugin', () => {
+  it('declares the `maz` plugin name', () => {
+    expect(mazPlugin.meta?.name).toBe('maz')
+  })
+
+  it('exposes the rules registry under `rules`', () => {
+    expect(mazPlugin.rules).toBe(rules)
+  })
+
+  it('registers tailwind-no-arbitrary-px', () => {
+    expect(mazPlugin.rules).toHaveProperty('tailwind-no-arbitrary-px')
+  })
+})

--- a/packages/eslint-config/src/configs/__tests__/declarative.test.ts
+++ b/packages/eslint-config/src/configs/__tests__/declarative.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { baseRules } from '../base'
+import { GLOBAL_IGNORES } from '../global'
+import { markdown } from '../markdown'
+import { sonarjsRules, sonarjsTestRules } from '../sonarjs'
+import { testRules } from '../test'
+import { vueRules, vueSfcOnlyRules } from '../vue'
+
+describe('baseRules', () => {
+  it('downgrades `no-console` to `warn` in development', () => {
+    const rules = baseRules(false)
+    expect(rules['no-console']).toEqual(['warn'])
+  })
+
+  it('escalates `no-console` to `error` in production', () => {
+    const rules = baseRules(true)
+    expect(rules['no-console']).toEqual(['error'])
+  })
+
+  it('declares the expected core rules', () => {
+    const rules = baseRules(true)
+    expect(rules['ts/no-unused-vars']).toEqual([
+      'error',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ])
+    expect(rules.complexity).toEqual(['error', { max: 20 }])
+    expect(rules['no-useless-assignment']).toBe('error')
+  })
+})
+
+describe('GLOBAL_IGNORES', () => {
+  it('includes the common build / dependency folders', () => {
+    expect(GLOBAL_IGNORES).toContain('**/node_modules')
+    expect(GLOBAL_IGNORES).toContain('**/dist')
+    expect(GLOBAL_IGNORES).toContain('**/coverage')
+    expect(GLOBAL_IGNORES).toContain('**/.nuxt')
+  })
+})
+
+describe('markdown', () => {
+  it('scopes to inline code blocks and relaxes a few rules', () => {
+    expect(markdown.files).toEqual(['**/*.md/**'])
+    expect(markdown.rules['no-console']).toBe('off')
+    expect(markdown.rules['ts/no-unused-vars']).toBe('off')
+  })
+})
+
+describe('sonarjs rules', () => {
+  it('keeps key quality rules on while turning off noisy ones', () => {
+    expect(sonarjsRules['sonarjs/cognitive-complexity']).toEqual(['error', 20])
+    expect(sonarjsRules['sonarjs/no-identical-functions']).toBe('error')
+    expect(sonarjsRules['sonarjs/no-duplicate-string']).toBe('off')
+  })
+
+  it('relaxes constraints in test files', () => {
+    expect(sonarjsTestRules['sonarjs/no-nested-functions']).toBe('off')
+    expect(sonarjsTestRules['sonarjs/cognitive-complexity']).toBe('off')
+  })
+})
+
+describe('testRules', () => {
+  it('disables max-nested-callbacks for test files', () => {
+    expect(testRules['max-nested-callbacks']).toBe('off')
+  })
+})
+
+describe('vueRules', () => {
+  it('enforces kebab-case for custom event names', () => {
+    expect(vueRules['vue/custom-event-name-casing']).toEqual(['error', 'kebab-case'])
+  })
+
+  it('disables `no-useless-assignment` only inside SFCs', () => {
+    expect(vueSfcOnlyRules['no-useless-assignment']).toBe('off')
+  })
+})

--- a/packages/eslint-config/src/configs/__tests__/logger.test.ts
+++ b/packages/eslint-config/src/configs/__tests__/logger.test.ts
@@ -1,0 +1,67 @@
+import type { LogLevel } from '../logger'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLogger } from '../logger'
+
+// consola writes through process.stdout/stderr. Stub them so the test runner
+// stays clean and we can verify visibility for each level.
+let stdoutSpy: ReturnType<typeof vi.spyOn>
+let stderrSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+})
+
+afterEach(() => {
+  stdoutSpy.mockRestore()
+  stderrSpy.mockRestore()
+})
+
+function totalWrites(): number {
+  return stdoutSpy.mock.calls.length + stderrSpy.mock.calls.length
+}
+
+describe('createLogger', () => {
+  it('returns an object with the expected methods', () => {
+    const logger = createLogger()
+    expect(typeof logger.setLevel).toBe('function')
+    expect(typeof logger.info).toBe('function')
+    expect(typeof logger.debug).toBe('function')
+    expect(typeof logger.verbose).toBe('function')
+    expect(typeof logger.box).toBe('function')
+  })
+
+  it.each([
+    'silent',
+    'error',
+    'warning',
+    'normal',
+    'default',
+    'debug',
+    'trace',
+    'verbose',
+  ] satisfies LogLevel[])('accepts level %s', (level) => {
+    const logger = createLogger()
+    expect(() => logger.setLevel(level)).not.toThrow()
+  })
+
+  it('silent level suppresses output for every method', () => {
+    const logger = createLogger()
+    logger.setLevel('silent')
+    logger.info('hello')
+    logger.debug('hello')
+    logger.verbose('hello')
+    logger.box({ title: 't', message: 'm' })
+    expect(totalWrites()).toBe(0)
+  })
+
+  it('verbose level lets every method through', () => {
+    const logger = createLogger()
+    logger.setLevel('verbose')
+    logger.info('hello')
+    logger.debug('hello')
+    logger.verbose('hello')
+    logger.box({ title: 't', message: 'm' })
+    expect(totalWrites()).toBeGreaterThan(0)
+  })
+})

--- a/packages/eslint-config/src/configs/__tests__/tailwindcss.test.ts
+++ b/packages/eslint-config/src/configs/__tests__/tailwindcss.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { mazPlugin } from '../../plugin'
+import { TAILWINDCSS_DEFAULT_FILES, tailwindcssConfigs } from '../tailwindcss'
+
+describe('tailwindcssConfigs', () => {
+  it('returns a single flat-config block scoped to the default files', () => {
+    const blocks = tailwindcssConfigs('recommended', {})
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].files).toBe(TAILWINDCSS_DEFAULT_FILES)
+  })
+
+  it('wires the `maz` plugin alongside `better-tailwindcss`', () => {
+    const [block] = tailwindcssConfigs('recommended', {})
+    expect(block.plugins?.maz).toBe(mazPlugin)
+    expect(block.plugins).toHaveProperty('better-tailwindcss')
+  })
+
+  it('disables the noisy better-tailwindcss rules by default', () => {
+    const [block] = tailwindcssConfigs('recommended', {})
+    expect(block.rules?.['better-tailwindcss/no-unknown-classes']).toBe('off')
+    expect(block.rules?.['better-tailwindcss/enforce-consistent-line-wrapping']).toBe('off')
+  })
+
+  it('forwards `entryPoint`, `tailwindConfig`, `cwd`, `tsconfig`, `detectComponentClasses` to plugin settings', () => {
+    const [block] = tailwindcssConfigs('recommended', {
+      entryPoint: '/app/app.css',
+      tailwindConfig: '/app/tailwind.config.ts',
+      detectComponentClasses: true,
+      cwd: '/app',
+      tsconfig: '/app/tsconfig.json',
+    })
+    const settings = (block.settings as any)['better-tailwindcss']
+    expect(settings).toEqual({
+      entryPoint: '/app/app.css',
+      tailwindConfig: '/app/tailwind.config.ts',
+      detectComponentClasses: true,
+      cwd: '/app',
+      tsconfig: '/app/tsconfig.json',
+    })
+  })
+
+  it('omits `better-tailwindcss` settings when nothing is provided', () => {
+    const [block] = tailwindcssConfigs('recommended', {})
+    expect((block.settings as any)['better-tailwindcss']).toEqual({})
+  })
+
+  describe('noArbitraryPx wiring', () => {
+    it('enables the rule with defaults when option is undefined', () => {
+      const [block] = tailwindcssConfigs('recommended', {})
+      expect(block.rules?.['maz/tailwind-no-arbitrary-px']).toEqual([
+        'error',
+        { baseFontSize: 16, unit: 'rem' },
+      ])
+    })
+
+    it('enables the rule with defaults when option is `true`', () => {
+      const [block] = tailwindcssConfigs('recommended', { noArbitraryPx: true })
+      expect(block.rules?.['maz/tailwind-no-arbitrary-px']).toEqual([
+        'error',
+        { baseFontSize: 16, unit: 'rem' },
+      ])
+    })
+
+    it('disables the rule when option is `false`', () => {
+      const [block] = tailwindcssConfigs('recommended', { noArbitraryPx: false })
+      const [severity] = block.rules?.['maz/tailwind-no-arbitrary-px'] as [string, unknown]
+      expect(severity).toBe('off')
+    })
+
+    it('passes custom `baseFontSize`, `unit`, and `severity`', () => {
+      const [block] = tailwindcssConfigs('recommended', {
+        noArbitraryPx: { baseFontSize: 10, unit: 'em', severity: 'warn' },
+      })
+      expect(block.rules?.['maz/tailwind-no-arbitrary-px']).toEqual([
+        'warn',
+        { baseFontSize: 10, unit: 'em' },
+      ])
+    })
+
+    it('fills missing keys when an object is partially provided', () => {
+      const [block] = tailwindcssConfigs('recommended', {
+        noArbitraryPx: { baseFontSize: 12 },
+      })
+      expect(block.rules?.['maz/tailwind-no-arbitrary-px']).toEqual([
+        'error',
+        { baseFontSize: 12, unit: 'rem' },
+      ])
+    })
+
+    it('defaults baseFontSize and severity when only `unit` is provided', () => {
+      const [block] = tailwindcssConfigs('recommended', {
+        noArbitraryPx: { unit: 'em' },
+      })
+      expect(block.rules?.['maz/tailwind-no-arbitrary-px']).toEqual([
+        'error',
+        { baseFontSize: 16, unit: 'em' },
+      ])
+    })
+  })
+})

--- a/packages/eslint-config/src/configs/tailwindcss.ts
+++ b/packages/eslint-config/src/configs/tailwindcss.ts
@@ -1,6 +1,7 @@
 import type { Linter } from 'eslint'
 import type { MazTailwindcssOptions, TailwindcssPreset } from '../types'
 import betterTailwindcss from 'eslint-plugin-better-tailwindcss'
+import { mazPlugin } from '../plugin'
 
 const TAILWINDCSS_FILES = ['**/*.{js,jsx,cjs,mjs,ts,mts,cts,tsx,vue,html,svelte,astro,astrojs,css,scss}']
 
@@ -10,11 +11,33 @@ const TAILWINDCSS_FILES = ['**/*.{js,jsx,cjs,mjs,ts,mts,cts,tsx,vue,html,svelte,
  */
 export const TAILWINDCSS_DEFAULT_FILES = TAILWINDCSS_FILES
 
+interface NoArbitraryPxResolved {
+  severity: 'off' | 'warn' | 'error'
+  options: { baseFontSize: number, unit: 'rem' | 'em' }
+}
+
+function resolveNoArbitraryPx(setting: MazTailwindcssOptions['noArbitraryPx']): NoArbitraryPxResolved {
+  if (setting === false)
+    return { severity: 'off', options: { baseFontSize: 16, unit: 'rem' } }
+  if (setting === undefined || setting === true) {
+    return { severity: 'error', options: { baseFontSize: 16, unit: 'rem' } }
+  }
+  return {
+    severity: setting.severity ?? 'error',
+    options: {
+      baseFontSize: setting.baseFontSize ?? 16,
+      unit: setting.unit ?? 'rem',
+    },
+  }
+}
+
 /**
  * Build the flat-config block(s) that wire up
- * `eslint-plugin-better-tailwindcss`. The plugin already ships preset
+ * `eslint-plugin-better-tailwindcss` AND the custom `maz/tailwind-*`
+ * rules shipped by this package. The plugin already ships preset
  * objects with `plugins` + `rules`; we spread them and add `files` plus
- * `settings['better-tailwindcss']` so the user's options reach the plugin.
+ * `settings['better-tailwindcss']` so the user's options reach the
+ * plugin.
  */
 export function tailwindcssConfigs(
   preset: TailwindcssPreset,
@@ -34,9 +57,15 @@ export function tailwindcssConfigs(
   if (settings.tsconfig)
     tailwindSettings.tsconfig = settings.tsconfig
 
+  const noArbitraryPx = resolveNoArbitraryPx(settings.noArbitraryPx)
+
   return [{
     ...presetConfig,
     files: TAILWINDCSS_FILES,
+    plugins: {
+      ...presetConfig.plugins,
+      maz: mazPlugin,
+    },
     settings: {
       'better-tailwindcss': tailwindSettings,
     },
@@ -44,6 +73,7 @@ export function tailwindcssConfigs(
       ...presetConfig.rules,
       'better-tailwindcss/no-unknown-classes': 'off',
       'better-tailwindcss/enforce-consistent-line-wrapping': 'off',
+      'maz/tailwind-no-arbitrary-px': [noArbitraryPx.severity, noArbitraryPx.options],
     },
   }]
 }

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -254,17 +254,23 @@ export function defineConfig(options: MazESLintOptions = {}, ...userConfigs: Maz
   log.verbose(`${TAG} Final config block count: ${additionalConfigs.length + userConfigs.length + 1} (additional: ${additionalConfigs.length}, user: ${userConfigs.length}, +markdown)`)
   log.verbose(`${TAG} Ignore globs: ${opts.ignores.length}`)
 
+  // User rule overrides go in a *trailing* block so they win over any
+  // additionalConfigs (vue/sonarjs/tailwindcss/…) that also set the same
+  // rule. Without this, an override like
+  // `rules: { 'maz/tailwind-no-arbitrary-px': ['error', { baseFontSize: 10 }] }`
+  // would be silently shadowed by `tailwindcssConfigs`.
+  const userRulesBlock: MazESLintUserConfig | undefined = opts.rules && Object.keys(opts.rules).length > 0
+    ? { rules: opts.rules }
+    : undefined
+
   return antfu({
     formatters: opts.formatters,
     ...opts,
-    rules: {
-      ...baseRules(env === 'production'),
-      ...opts.rules,
-    },
+    rules: baseRules(env === 'production'),
     ignores: (() => {
       return opts.ignores
     }) as any,
-  }, ...additionalConfigs, ...userConfigs, markdown) as MazESLintConfig
+  }, ...additionalConfigs, ...userConfigs, ...(userRulesBlock ? [userRulesBlock] : []), markdown) as MazESLintConfig
 }
 
 // Export individual configs for advanced usage
@@ -273,5 +279,8 @@ export { baseRules } from './configs/base'
 export { sonarjsRules, sonarjsTestRules } from './configs/sonarjs'
 export { TAILWINDCSS_DEFAULT_FILES, tailwindcssConfigs } from './configs/tailwindcss'
 export { vueRules, vueSfcOnlyRules } from './configs/vue'
+// Custom rules / plugin
+export { mazPlugin } from './plugin'
+export { rules as mazRules } from './rules'
 // Export types
 export type { MazESLintConfig, MazESLintOptions, MazTailwindcssOptions, TailwindcssPreset } from './types'

--- a/packages/eslint-config/src/plugin.ts
+++ b/packages/eslint-config/src/plugin.ts
@@ -1,0 +1,21 @@
+import type { ESLint } from 'eslint'
+import { rules } from './rules'
+
+/**
+ * The `maz` ESLint plugin bundling all custom rules shipped by
+ * `@maz-ui/eslint-config`. Rules are namespaced by category:
+ *
+ *   - `maz/tailwind-*` — Tailwind-specific rules
+ *   - `maz/js-*` — general JS/TS rules (when added)
+ *   - …
+ *
+ * The plugin is auto-wired by the relevant config block in
+ * `src/configs/*.ts`, but it is also exported so users can compose
+ * their own flat-config setup.
+ */
+export const mazPlugin: ESLint.Plugin = {
+  meta: {
+    name: 'maz',
+  },
+  rules,
+}

--- a/packages/eslint-config/src/rules/index.ts
+++ b/packages/eslint-config/src/rules/index.ts
@@ -1,0 +1,16 @@
+import type { Rule } from 'eslint'
+import tailwindNoArbitraryPx from './tailwind/no-arbitrary-px'
+
+/**
+ * Registry of all custom rules shipped by `@maz-ui/eslint-config`.
+ *
+ * Keys here are the final rule names exposed by the `maz` plugin, so a
+ * file in `src/rules/tailwind/no-arbitrary-px.ts` becomes
+ * `maz/tailwind-no-arbitrary-px` when wired through the plugin.
+ *
+ * Add new rules by dropping a file in the matching category folder
+ * (`tailwind/`, `js/`, …) and registering it below.
+ */
+export const rules: Record<string, Rule.RuleModule> = {
+  'tailwind-no-arbitrary-px': tailwindNoArbitraryPx,
+}

--- a/packages/eslint-config/src/rules/tailwind/__tests__/no-arbitrary-px.test.ts
+++ b/packages/eslint-config/src/rules/tailwind/__tests__/no-arbitrary-px.test.ts
@@ -1,0 +1,136 @@
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import { afterAll, describe, it } from 'vitest'
+import vueParser from 'vue-eslint-parser'
+import rule from '../no-arbitrary-px'
+
+RuleTester.afterAll = afterAll
+RuleTester.it = it
+RuleTester.describe = describe
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('tailwind-no-arbitrary-px', rule as never, {
+  valid: [
+    // No bracket / no px → fine.
+    { code: 'const a = "w-4 h-full text-sm"' },
+    { code: 'const a = "p-[1rem] m-[0.5rem]"' },
+    // English text in brackets with spaces → not a Tailwind class.
+    { code: 'const a = "Width can be up to 100px wide"' },
+    // px outside brackets → not a Tailwind arbitrary value (ignored).
+    { code: 'const a = "border: 1px solid red"' },
+    // calc with already-rem values.
+    { code: 'const a = "w-[calc(100%-1rem)]"' },
+    // Bracket without a digit-px (eg. data attribute selector).
+    { code: 'const a = "data-[active]:bg-blue"' },
+    // Non-string literals must be ignored.
+    { code: 'const n = 16' },
+    { code: 'const b = true' },
+    { code: 'const nope = null' },
+    // Vue SFC static attribute without px → no report.
+    {
+      code: '<template><div class="w-4 h-full"></div></template>',
+      filename: 'static-clean.vue',
+      languageOptions: { parser: vueParser },
+    },
+  ],
+
+  invalid: [
+    // Simple positive integer.
+    {
+      code: 'const a = "w-[16px]"',
+      output: 'const a = "w-[1rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Negative value (the user-reported `m-[-16px]` shape).
+    {
+      code: 'const a = "m-[-16px]"',
+      output: 'const a = "m-[-1rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Decimal value.
+    {
+      code: 'const a = "tracking-[1.5px]"',
+      output: 'const a = "tracking-[0.09375rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Bare decimal (.5px).
+    {
+      code: 'const a = "tracking-[.5px]"',
+      output: 'const a = "tracking-[0.03125rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Multiple px values inside the same bracket (Tailwind uses `_` for spaces).
+    {
+      code: 'const a = "p-[16px_8px]"',
+      output: 'const a = "p-[1rem_0.5rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Multiple Tailwind classes in one string, each with px.
+    {
+      code: 'const a = "w-[16px] h-[24px]"',
+      output: 'const a = "w-[1rem] h-[1.5rem]"',
+      errors: [
+        { messageId: 'preferRelativeUnit' },
+        { messageId: 'preferRelativeUnit' },
+      ],
+    },
+    // Variant prefix.
+    {
+      code: 'const a = "md:hover:w-[16px]"',
+      output: 'const a = "md:hover:w-[1rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Arbitrary property syntax.
+    {
+      code: 'const a = "[gap:16px]"',
+      output: 'const a = "[gap:1rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // calc() with px.
+    {
+      code: 'const a = "w-[calc(100%-16px)]"',
+      output: 'const a = "w-[calc(100%-1rem)]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Template literal.
+    {
+      code: 'const a = `w-[16px]`',
+      output: 'const a = `w-[1rem]`',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Custom baseFontSize option.
+    {
+      code: 'const a = "w-[10px]"',
+      options: [{ baseFontSize: 10 }],
+      output: 'const a = "w-[1rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Custom unit option.
+    {
+      code: 'const a = "w-[16px]"',
+      options: [{ unit: 'em' }],
+      output: 'const a = "w-[1em]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Uppercase PX still flagged.
+    {
+      code: 'const a = "w-[16PX]"',
+      output: 'const a = "w-[1rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Non-divisible value preserves precision (15/16 = 0.9375).
+    {
+      code: 'const a = "w-[15px]"',
+      output: 'const a = "w-[0.9375rem]"',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+    // Vue SFC static class attribute (parsed via vue-eslint-parser).
+    {
+      code: '<template><div class="w-[16px]"></div></template>',
+      filename: 'static-px.vue',
+      languageOptions: { parser: vueParser },
+      output: '<template><div class="w-[1rem]"></div></template>',
+      errors: [{ messageId: 'preferRelativeUnit' }],
+    },
+  ],
+})

--- a/packages/eslint-config/src/rules/tailwind/no-arbitrary-px.ts
+++ b/packages/eslint-config/src/rules/tailwind/no-arbitrary-px.ts
@@ -1,0 +1,170 @@
+import type { Rule } from 'eslint'
+
+export interface NoArbitraryPxOptions {
+  /**
+   * Root font size, in pixels, used to convert `Npx` to `rem`/`em`.
+   *
+   * @default 16
+   */
+  baseFontSize?: number
+
+  /**
+   * Output unit for the autofix.
+   *
+   * @default 'rem'
+   */
+  unit?: 'rem' | 'em'
+}
+
+const DEFAULT_BASE_FONT_SIZE = 16
+const DEFAULT_UNIT: 'rem' | 'em' = 'rem'
+
+/**
+ * Match a Tailwind arbitrary value bracket pair `[...]`. The content is
+ * captured but literal whitespace is forbidden — Tailwind encodes spaces
+ * as `_` inside arbitrary values, so any bracket with real spaces is
+ * plain prose (e.g. `[up to 100px]`) and must be left alone.
+ *
+ * The `px` filter is applied separately on the captured content with
+ * {@link HAS_PX_VALUE} to keep this regex linear (no backtracking — the
+ * trailing `\]` is the unambiguous terminator).
+ */
+// eslint-disable-next-line sonarjs/slow-regex -- bounded by the literal `]` terminator; no backtracking
+const ARBITRARY_BRACKET = /\[([^\s\]]+)\]/g
+
+/** Quick presence check: does the bracket body contain a px value? */
+const HAS_PX_VALUE = /\dpx/i
+
+/**
+ * Match a single px value (supports negatives like `-16px` from
+ * `m-[-16px]`, decimals like `1.5px`, and bare decimals like `.5px`).
+ *
+ * The two alternatives are mutually exclusive — `\d+(?:\.\d+)?` requires
+ * a leading digit, `\.\d+` requires a leading dot — so the regex stays
+ * linear (no overlapping backtracking).
+ */
+// eslint-disable-next-line sonarjs/slow-regex -- alternatives are disjoint; no backtracking
+const PX_VALUE = /(-?(?:\d+(?:\.\d+)?|\.\d+))px/gi
+
+function convertPx(pxStr: string, base: number, unit: 'rem' | 'em'): string {
+  const px = Number.parseFloat(pxStr)
+  const value = px / base
+  // Trim trailing zeros and avoid floating-point noise.
+  const formatted = Number.parseFloat(value.toFixed(6)).toString()
+  return `${formatted}${unit}`
+}
+
+interface Replacement {
+  original: string
+  fixed: string
+  index: number
+  length: number
+}
+
+function findReplacements(input: string, base: number, unit: 'rem' | 'em'): Replacement[] {
+  const out: Replacement[] = []
+  for (const match of input.matchAll(ARBITRARY_BRACKET)) {
+    const full = match[0]
+    const inner = match[1]
+    if (!HAS_PX_VALUE.test(inner))
+      continue
+    const fixedInner = inner.replace(PX_VALUE, (_m, num: string) => convertPx(num, base, unit))
+    // `matchAll` always populates `index` on the match objects it yields.
+    out.push({
+      original: full,
+      fixed: `[${fixedInner}]`,
+      index: match.index as number,
+      length: full.length,
+    })
+  }
+  return out
+}
+
+function applyReplacements(input: string, replacements: Replacement[]): string {
+  let output = ''
+  let cursor = 0
+  for (const r of replacements) {
+    output += input.slice(cursor, r.index) + r.fixed
+    cursor = r.index + r.length
+  }
+  output += input.slice(cursor)
+  return output
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow `px` units inside Tailwind arbitrary value classes; prefer `rem` (or `em`).',
+      recommended: false,
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          baseFontSize: { type: 'number', minimum: 1 },
+          unit: { type: 'string', enum: ['rem', 'em'] },
+        },
+      },
+    ],
+    messages: {
+      preferRelativeUnit: 'Tailwind class uses px; replace `{{original}}` with `{{fixed}}`.',
+    },
+  },
+  create(context) {
+    const options = (context.options[0] ?? {}) as NoArbitraryPxOptions
+    const base = options.baseFontSize ?? DEFAULT_BASE_FONT_SIZE
+    const unit = options.unit ?? DEFAULT_UNIT
+    const { sourceCode } = context
+
+    function check(node: Rule.Node | { type: string, range: [number, number] }): void {
+      const raw = sourceCode.getText(node as Rule.Node)
+      const replacements = findReplacements(raw, base, unit)
+      if (replacements.length === 0)
+        return
+      const fixedRaw = applyReplacements(raw, replacements)
+      for (const r of replacements) {
+        context.report({
+          node: node as Rule.Node,
+          messageId: 'preferRelativeUnit',
+          data: { original: r.original, fixed: r.fixed },
+          fix: fixer => fixer.replaceText(node as Rule.Node, fixedRaw),
+        })
+      }
+    }
+
+    const jsVisitor: Rule.RuleListener = {
+      Literal(node) {
+        if (typeof node.value !== 'string')
+          return
+        check(node)
+      },
+      TemplateElement(node) {
+        check(node)
+      },
+    }
+
+    // Vue SFC: the template body is parsed separately by `vue-eslint-parser`
+    // and walked via `defineTemplateBodyVisitor` instead of the standard
+    // listener map. Falls through to the plain JS visitor in non-Vue files.
+    const parserServices = context.sourceCode.parserServices as {
+      defineTemplateBodyVisitor?: (
+        templateVisitor: Record<string, (node: any) => void>,
+        scriptVisitor?: Rule.RuleListener,
+      ) => Rule.RuleListener
+    }
+
+    if (parserServices.defineTemplateBodyVisitor) {
+      return parserServices.defineTemplateBodyVisitor(
+        { VLiteral: (node: any) => check(node) },
+        jsVisitor,
+      )
+    }
+
+    return jsVisitor
+  },
+}
+
+export default rule

--- a/packages/eslint-config/src/types.ts
+++ b/packages/eslint-config/src/types.ts
@@ -52,6 +52,38 @@ export interface MazTailwindcssOptions {
    * Tailwind config.
    */
   tsconfig?: string
+
+  /**
+   * Configure the `maz/tailwind-no-arbitrary-px` rule (forbids `px`
+   * values inside Tailwind arbitrary value classes such as `w-[16px]`).
+   *
+   * - `false`: disable the rule.
+   * - `true` *(default)*: enable with defaults (`baseFontSize: 16`,
+   *   `unit: 'rem'`).
+   * - Object: enable with custom options.
+   */
+  noArbitraryPx?: boolean | {
+    /**
+     * Root font size, in pixels, used to convert `Npx` to `rem`/`em`.
+     *
+     * @default 16
+     */
+    baseFontSize?: number
+
+    /**
+     * Output unit for the autofix.
+     *
+     * @default 'rem'
+     */
+    unit?: 'rem' | 'em'
+
+    /**
+     * ESLint severity for the rule.
+     *
+     * @default 'error'
+     */
+    severity?: 'off' | 'warn' | 'error'
+  }
 }
 
 export interface MazESLintOptions extends OptionsConfig {

--- a/packages/eslint-config/vitest.config.ts
+++ b/packages/eslint-config/vitest.config.ts
@@ -1,0 +1,39 @@
+/// <reference types="vitest" />
+
+import { coverageConfigDefaults, defaultExclude, defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  logLevel: process.env.CI ? 'error' : 'info',
+  test: {
+    silent: !!process.env.CI,
+    hideSkippedTests: !!process.env.CI,
+    reporters: process.env.CI ? ['dot'] : ['tree'],
+    environment: 'node',
+    env: {
+      TZ: 'UTC',
+    },
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['clover', 'html', 'lcov', 'text', 'text-summary'],
+      include: ['src/**/*.ts'],
+      exclude: [
+        ...coverageConfigDefaults.exclude,
+        'src/types.ts',
+      ],
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100,
+        autoUpdate: !process.env.CI,
+      },
+    },
+    exclude: [
+      ...defaultExclude,
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/coverage/**',
+    ],
+  },
+})

--- a/packages/eslint-config/vitest.config.ts
+++ b/packages/eslint-config/vitest.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
       TZ: 'UTC',
     },
     globals: true,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     coverage: {
       provider: 'v8',
       reporter: ['clover', 'html', 'lcov', 'text', 'text-summary'],

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -52,10 +52,10 @@ export default defineConfig({
         'src/**/types.ts',
       ],
       thresholds: {
-        lines: 90.47,
-        functions: 89.34,
+        lines: 90.49,
+        functions: 89.4,
         branches: 83.45,
-        statements: 90.6,
+        statements: 90.62,
         autoUpdate: !process.env.CI,
       },
     },

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       thresholds: {
         lines: 95.58,
         functions: 99.19,
-        branches: 87.24,
+        branches: 87,
         statements: 95.73,
         autoUpdate: !process.env.CI,
       },


### PR DESCRIPTION
## Summary
- New custom ESLint plugin under the `maz/*` namespace shipped by `@maz-ui/eslint-config`, starting with `maz/tailwind-no-arbitrary-px` which forbids `px` units inside Tailwind arbitrary value classes (e.g. `w-[16px]`, `[gap:24px]`) and autofixes them to `rem` / `em`.
- Plugin + rule are wired automatically when `tailwindcss` is enabled in `defineConfig`. Tunable via the `tailwindcss.noArbitraryPx` shortcut or a standard ESLint `rules` override (trailing block, so user overrides win).
- Adds vitest setup, unit tests for the rule + configs, README + docs site sections covering the new rule, and Codecov upload/flags for `eslint-config` and `stylelint-config` (drops obsolete `forms`/`icons`/`maz-cli`).

## Test plan
- [ ] `pnpm --filter @maz-ui/eslint-config test:unit` passes
- [ ] `pnpm --filter @maz-ui/eslint-config typecheck` passes
- [ ] `pnpm --filter @maz-ui/eslint-config build` passes
- [ ] Manual: in a consumer with `tailwindcss: 'recommended'`, classes like `w-[16px]` are flagged and autofixed to `w-[1rem]`; whitespace-bearing brackets like `[up to 100px]` are left alone
- [ ] Manual: `tailwindcss.noArbitraryPx: { baseFontSize: 10, unit: 'em' }` shortcut and `rules: { 'maz/tailwind-no-arbitrary-px': ['error', { baseFontSize: 10 }] }` override both take effect
- [ ] Manual: with `tailwindcss: false`, neither the `maz` plugin nor the rule appear in the resolved flat-config
- [ ] CI: Codecov uploads succeed for `eslint-config` and `stylelint-config` flags