### PR TITLE
fix(@maz-ui/nuxt): color mode reverts to dark on client navigation

### DIFF
--- a/packages/nuxt/src/runtime/plugins/__tests__/theme.server.spec.ts
+++ b/packages/nuxt/src/runtime/plugins/__tests__/theme.server.spec.ts
@@ -244,4 +244,38 @@ describe('theme plugin (server)', () => {
       htmlAttrs: { class: 'dark' },
     })
   })
+
+  describe('Given the plugin renders on the server', () => {
+    describe('When colorMode is dark and darkModeStrategy is class', () => {
+      it('Then it bakes the dark class into the SSR html via useHead', async () => {
+        const context = createContext({ colorMode: 'dark', darkModeStrategy: 'class' })
+        await (themePlugin as (...args: any[]) => any)(context)
+        expect(mockUseHead).toHaveBeenCalledWith({
+          htmlAttrs: { class: 'dark' },
+        })
+      })
+    })
+
+    describe('When colorMode is light', () => {
+      it('Then no htmlAttrs class entry is registered', async () => {
+        const context = createContext({ colorMode: 'light' })
+        await (themePlugin as (...args: any[]) => any)(context)
+        const htmlAttrsCalls = mockUseHead.mock.calls.filter(
+          ([arg]: any[]) => arg.htmlAttrs?.class !== undefined,
+        )
+        expect(htmlAttrsCalls).toHaveLength(0)
+      })
+    })
+
+    describe('When isDark is true but darkModeStrategy is media', () => {
+      it('Then no htmlAttrs class entry is registered', async () => {
+        const context = createContext({ colorMode: 'dark', darkModeStrategy: 'media' })
+        await (themePlugin as (...args: any[]) => any)(context)
+        const htmlAttrsCalls = mockUseHead.mock.calls.filter(
+          ([arg]: any[]) => arg.htmlAttrs?.class !== undefined,
+        )
+        expect(htmlAttrsCalls).toHaveLength(0)
+      })
+    })
+  })
 })

--- a/packages/nuxt/src/runtime/plugins/__tests__/theme.spec.ts
+++ b/packages/nuxt/src/runtime/plugins/__tests__/theme.spec.ts
@@ -113,30 +113,36 @@ describe('theme plugin', () => {
     )
   })
 
-  it('should add dark class to html when colorMode is dark and strategy is class', async () => {
+  it('does not register htmlAttrs class via useHead on client when colorMode is dark', async () => {
     const context = createContext({ colorMode: 'dark', darkModeStrategy: 'class' })
     await (themePlugin as (...args: any[]) => any)(context)
-    expect(mockUseHead).toHaveBeenCalledWith({
-      htmlAttrs: { class: 'dark' },
-    })
+    const htmlAttrsCalls = mockUseHead.mock.calls.filter(
+      ([arg]) => arg.htmlAttrs?.class !== undefined,
+    )
+    expect(htmlAttrsCalls).toHaveLength(0)
   })
 
-  it('should not add dark class when colorMode is light', async () => {
+  it('does not register htmlAttrs class via useHead on client when colorMode is light', async () => {
     const context = createContext({ colorMode: 'light' })
     await (themePlugin as (...args: any[]) => any)(context)
-    const darkClassCalls = mockUseHead.mock.calls.filter(
-      ([arg]) => arg.htmlAttrs?.class === 'dark',
+    const htmlAttrsCalls = mockUseHead.mock.calls.filter(
+      ([arg]) => arg.htmlAttrs?.class !== undefined,
     )
-    expect(darkClassCalls).toHaveLength(0)
+    expect(htmlAttrsCalls).toHaveLength(0)
   })
 
-  it('should detect dark mode from system when colorMode is auto on client', async () => {
+  it('detects dark mode from system when colorMode is auto on client and forwards isDark to install', async () => {
     mockGetSystemColorMode.mockReturnValue('dark')
     const context = createContext({ colorMode: 'auto', mode: 'both' })
     await (themePlugin as (...args: any[]) => any)(context)
-    expect(mockUseHead).toHaveBeenCalledWith({
-      htmlAttrs: { class: 'dark' },
-    })
+    expect(mockInstall).toHaveBeenCalledWith(
+      context.vueApp,
+      expect.objectContaining({ _isDark: true }),
+    )
+    const htmlAttrsCalls = mockUseHead.mock.calls.filter(
+      ([arg]) => arg.htmlAttrs?.class !== undefined,
+    )
+    expect(htmlAttrsCalls).toHaveLength(0)
   })
 
   it('should set isDark true when mode is dark', async () => {
@@ -169,7 +175,7 @@ describe('theme plugin', () => {
     )
   })
 
-  it('should use resolved color mode cookie when color mode cookie is auto', async () => {
+  it('uses resolved color mode cookie when color mode cookie is auto and forwards isDark to install', async () => {
     mockUseCookie.mockImplementation(((name: string) => {
       if (name === 'maz-color-mode') {
         return { value: 'auto' }
@@ -181,9 +187,10 @@ describe('theme plugin', () => {
     }) as any)
     const context = createContext({ colorMode: 'auto', mode: 'both' })
     await (themePlugin as (...args: any[]) => any)(context)
-    expect(mockUseHead).toHaveBeenCalledWith({
-      htmlAttrs: { class: 'dark' },
-    })
+    expect(mockInstall).toHaveBeenCalledWith(
+      context.vueApp,
+      expect.objectContaining({ _isDark: true }),
+    )
   })
 
   it('should ignore invalid resolved color mode cookie values', async () => {
@@ -331,5 +338,36 @@ describe('theme plugin', () => {
     expect(presetCookie.value).toBe('nova')
     // The cookie value was NOT used as preset name to resolve.
     expect(mockGetPreset).not.toHaveBeenCalledWith('nova')
+  })
+
+  describe('Given the plugin boots on the client with darkModeStrategy class', () => {
+    describe.each([
+      { label: 'colorMode dark', themeOptions: { colorMode: 'dark', mode: 'both' } },
+      { label: 'colorMode auto with system dark', themeOptions: { colorMode: 'auto', mode: 'both' }, systemColorMode: 'dark' as const },
+      { label: 'colorMode auto with resolved cookie dark', themeOptions: { colorMode: 'auto', mode: 'both' }, resolvedCookie: 'dark' as const },
+      { label: 'mode dark', themeOptions: { colorMode: 'light', mode: 'dark' } },
+    ])('When isDark resolves to true via $label', ({ themeOptions, systemColorMode, resolvedCookie }) => {
+      it('Then no htmlAttrs entry is registered via useHead so navigation cannot re-apply the boot class', async () => {
+        if (systemColorMode) {
+          mockGetSystemColorMode.mockReturnValue(systemColorMode)
+        }
+        if (resolvedCookie) {
+          mockUseCookie.mockImplementation(((name: string) => {
+            if (name === 'maz-resolved-color-mode') {
+              return { value: resolvedCookie }
+            }
+            return { value: undefined }
+          }) as any)
+        }
+
+        const context = createContext(themeOptions)
+        await (themePlugin as (...args: any[]) => any)(context)
+
+        const htmlAttrsCalls = mockUseHead.mock.calls.filter(
+          ([arg]) => arg.htmlAttrs !== undefined,
+        )
+        expect(htmlAttrsCalls).toHaveLength(0)
+      })
+    })
   })
 })

--- a/packages/nuxt/src/runtime/plugins/theme.ts
+++ b/packages/nuxt/src/runtime/plugins/theme.ts
@@ -138,15 +138,15 @@ export default defineNuxtPlugin(async ({ vueApp, $config }) => {
     ? getInitialColorMode() === 'dark'
     : config.colorMode === 'dark' || config.mode === 'dark'
 
-  if (isDark && config.darkModeStrategy === 'class') {
-    useHead({
-      htmlAttrs: {
-        class: config.darkClass,
-      },
-    })
-  }
-
   if (import.meta.server) {
+    if (isDark && config.darkModeStrategy === 'class') {
+      useHead({
+        htmlAttrs: {
+          class: config.darkClass,
+        },
+      })
+    }
+
     injectThemeCSS(config)
 
     useHead({


### PR DESCRIPTION
## Contexte

Sur Nuxt, après avoir basculé du dark vers le light via `useTheme().setColorMode('light')` (ou `toggleDarkMode()`), la première navigation client repassait l'app en dark. Un hard reload, lui, conservait bien le light. Bug ouvert dans `@maz-ui/nuxt`, pas dans `@maz-ui/themes` ni en Vue pur.

**Cause racine** : le plugin `packages/nuxt/src/runtime/plugins/theme.ts` enregistrait `useHead({ htmlAttrs: { class: darkClass } })` au boot, **sur server et client**. Côté client, cette entrée `@unhead` persiste pour toute la session ; à chaque réconciliation de head (donc à chaque navigation), elle ré-applique la classe `dark` que `setColorMode` venait d'enlever du `<html>`. Le hard reload rejouait le plugin avec le cookie déjà à `light`, d'où la disparition du symptôme.

## Changements

- `packages/nuxt/src/runtime/plugins/theme.ts` : `useHead({ htmlAttrs: { class: darkClass } })` est maintenant à l'intérieur du bloc `if (import.meta.server)`. Côté client, `setupTheme` (mutation observer + watch sur `themeState.colorMode`) reste seul maître de la classe `<html>`, ce qui correspond au flux déjà en place pour Vue pur.
- `packages/nuxt/src/runtime/plugins/__tests__/theme.spec.ts` : les assertions client qui attendaient `useHead({ htmlAttrs: ... })` sont retournées (vérifient que **rien** n'est enregistré côté client) ; ajout d'un bloc `describe.each` de régression couvrant les 4 chemins par lesquels `isDark` peut être vrai au boot.
- `packages/nuxt/src/runtime/plugins/__tests__/theme.server.spec.ts` : ajout des scénarios miroir (colorMode dark + class, light, dark + media) pour préserver la couverture de branche du `if (isDark && darkModeStrategy === 'class')`.

## Tests

- Tests unitaires Vitest dans `packages/nuxt` (split projects `client` / `server` via `import.meta.server` define).
- Coverage `@maz-ui/nuxt` reste à 100% (statements / branches / functions / lines).
- `pnpm health` vert (lint:fix, typecheck, test:unit:coverage, build sur 12 projets).

### Vérification manuelle suggérée

1. Dans une app Nuxt consommatrice, démarrer en dark mode.
2. Appeler `useTheme().setColorMode('light')` (ou `toggleDarkMode()`).
3. Naviguer sur une autre route via `<NuxtLink>` ou `navigateTo()`.
4. La page doit rester en light. Avant le fix, elle repassait en dark.