### PR TITLE
feat(@maz-ui/themes): MazDialog - configurable max/min-width via preset

### DIFF
--- a/apps/docs/src/components/maz-dialog.md
+++ b/apps/docs/src/components/maz-dialog.md
@@ -103,10 +103,56 @@ For long content, you can enable scrolling in content part (Header and footer sl
   </template>
 </ComponentDemo>
 
+## Width
+
+On tablet and up, the dialog is sized by two CSS variables coming from the active theme preset (`components.dialog`):
+
+- `--maz-dialog-max-width` (default `38rem`)
+- `--maz-dialog-min-width` (default `32rem`)
+
+You can set these defaults globally per preset — see [the theme `components.dialog` documentation](./../ecosystem/themes.md#dialog-sizing). To change the width of a single dialog, pass the `max-width` / `min-width` props — they always override the preset:
+
+<ComponentDemo>
+  <MazBtn @click="widthOpened = true">Open Wide Dialog</MazBtn>
+
+  <MazDialog v-model="widthOpened" title="Custom width" max-width="50rem" min-width="40rem">
+    <p>
+      This dialog overrides the preset width through props.
+    </p>
+    <template #footer="{ close }">
+      <MazBtn @click="close">
+        Confirm
+      </MazBtn>
+    </template>
+  </MazDialog>
+
+<template #code>
+
+```vue
+<template>
+  <MazDialog
+    v-model="isOpen"
+    title="Custom width"
+    max-width="50rem"
+    min-width="40rem"
+  >
+    <p>This dialog overrides the preset width through props.</p>
+  </MazDialog>
+</template>
+```
+
+  </template>
+</ComponentDemo>
+
+::: tip
+The default widths are expressed in `rem`, so they scale with the preset's `base-font-size`. Presets with a larger base size (e.g. `ocean` at `16px`) ship rem values adjusted to keep the rendered pixel width consistent across presets.
+:::
+
 <!--@include: ./../../.vitepress/generated-docs/maz-dialog.doc.md-->
 
 <script setup>
   import { ref } from 'vue'
   const isOpen = ref(false)
   const scollableOpened = ref(false)
+  const widthOpened = ref(false)
 </script>

--- a/apps/docs/src/ecosystem/themes.md
+++ b/apps/docs/src/ecosystem/themes.md
@@ -593,6 +593,27 @@ const surfaceTheme = definePreset({
 
 Components consume these via `maz:bg-container` / `maz:bg-input` Tailwind utilities, so a single override propagates everywhere — no per-component class hunt.
 
+### Dialog sizing
+
+`components.dialog` controls the width of [`MazDialog`](./../components/maz-dialog.md) on tablet and up. The two keys are emitted as `--maz-dialog-max-width` / `--maz-dialog-min-width` and consumed by the component through `var(--maz-dialog-max-width, 38rem)` / `var(--maz-dialog-min-width, 32rem)`:
+
+```typescript
+const wideDialogTheme = definePreset({
+  base: 'maz-ui',
+  overrides: {
+    name: 'wide-dialogs',
+    components: {
+      dialog: {
+        'max-width': '48rem',
+        'min-width': '36rem',
+      },
+    },
+  },
+})
+```
+
+Both values are in `rem`, so they scale with the preset's `base-font-size`. Bundled presets anchored on `14px` use `38rem` / `32rem`; `ocean` (`16px`) ships scaled rem values (`33.25rem` / `28rem`) to keep the same rendered pixel width. The `max-width` / `min-width` props on `MazDialog` still override the preset per instance.
+
 ## useTheme Composable API
 
 ```typescript
@@ -957,6 +978,8 @@ Per-component knobs under `components.<key>`. All optional — omit to fall back
 | `btn.font-weight` | `--maz-btn-font-weight` | Font-weight on `.m-btn`. Defaults to `'500'`. |
 | `container.bg.light` / `.dark` | `--maz-container-bg` (per mode) | Background of `Card`, `Container`, `Dialog`, `Popover`, `Drawer`, … Defaults to `var(--maz-surface)`. Bridged to `--color-container`. |
 | `input.bg.light` / `.dark` | `--maz-input-bg` (per mode) | Background of `Input`, `Textarea`, `Select`, `Checkbox`, … Defaults to `var(--maz-surface)` light, `var(--maz-surface-400)` dark. Bridged to `--color-input`. |
+| `dialog.max-width` | `--maz-dialog-max-width` | Max-width of `MazDialog` on tablet and up. Defaults to `38rem` (`33.25rem` on `ocean`). Overridable via the `max-width` prop. |
+| `dialog.min-width` | `--maz-dialog-min-width` | Min-width of `MazDialog` on tablet and up. Defaults to `32rem` (`28rem` on `ocean`). Overridable via the `min-width` prop. |
 
 ### Sample output
 

--- a/packages/lib/src/components/MazDialog.vue
+++ b/packages/lib/src/components/MazDialog.vue
@@ -26,8 +26,8 @@ defineOptions({
 
 const {
   modelValue,
-  maxWidth = '100%',
-  minWidth = '32rem',
+  maxWidth = 'var(--maz-dialog-max-width, 38rem)',
+  minWidth = 'var(--maz-dialog-min-width, 32rem)',
   scrollable,
   closeOnEscape = true,
   ...backdropProps
@@ -51,9 +51,15 @@ export interface DialogProps {
   title?: string
   /** Remove the close button in header */
   hideCloseButton?: boolean
-  /** Modal's max-width */
+  /**
+   * Modal's max-width.
+   * @default Theme preset `components.dialog.max-width` via `var(--maz-dialog-max-width, 38rem)`
+   */
   maxWidth?: string
-  /** Modal's min-width */
+  /**
+   * Modal's min-width.
+   * @default Theme preset `components.dialog.min-width` via `var(--maz-dialog-min-width, 32rem)`
+   */
   minWidth?: string
   /**  Modal's content becomes scrollable - warning: a overflow is applied */
   scrollable?: boolean

--- a/packages/lib/tests/specs/components/MazDialog-extended.spec.ts
+++ b/packages/lib/tests/specs/components/MazDialog-extended.spec.ts
@@ -153,12 +153,12 @@ describe('MazDialog extended coverage', () => {
   })
 
   describe('when using default maxWidth and minWidth', () => {
-    it('should set default CSS variables', () => {
+    it('should fall back to the theme preset CSS variables', () => {
       const wrapper = getWrapper({ modelValue: true })
       const dialog = wrapper.find('.m-dialog')
       const style = dialog.attributes('style')
-      expect(style).toContain('--max-width: 100%')
-      expect(style).toContain('--min-width: 32rem')
+      expect(style).toContain('--max-width: var(--maz-dialog-max-width, 38rem)')
+      expect(style).toContain('--min-width: var(--maz-dialog-min-width, 32rem)')
     })
   })
 

--- a/packages/themes/src/presets/_defaults.ts
+++ b/packages/themes/src/presets/_defaults.ts
@@ -1,4 +1,4 @@
-import type { RoundedScaleKey, ThemeComponentBg, ThemeFoundation, ThemeScales } from '../types'
+import type { RoundedScaleKey, ThemeComponentBg, ThemeComponents, ThemeFoundation, ThemeScales } from '../types'
 
 /**
  * Defaults shared across the bundled presets. Each preset can spread these
@@ -75,3 +75,15 @@ export const DEFAULT_INPUT_TOP_LABEL_FONT_WEIGHT = '600'
  * heavier or lighter for their visual identity.
  */
 export const DEFAULT_BTN_FONT_WEIGHT = '500'
+
+/**
+ * Default `max-width` / `min-width` for `MazDialog` on tablet and up.
+ * Anchored on a 14px `base-font-size` (38rem ≈ 532px, 32rem ≈ 448px).
+ * Presets with a different `base-font-size` (e.g. ocean at 16px) should
+ * scale these in rem to keep the rendered pixel width consistent.
+ * Consumed by the component via `var(--maz-dialog-max-width, 38rem)` /
+ * `var(--maz-dialog-min-width, 32rem)`, and still overridable per-instance
+ * through the `max-width` / `min-width` props.
+ */
+export const DEFAULT_DIALOG_MAX_WIDTH: NonNullable<ThemeComponents['dialog']>['max-width'] = '38rem'
+export const DEFAULT_DIALOG_MIN_WIDTH: NonNullable<ThemeComponents['dialog']>['min-width'] = '32rem'

--- a/packages/themes/src/presets/mazUi.ts
+++ b/packages/themes/src/presets/mazUi.ts
@@ -2,6 +2,8 @@ import type { ThemePreset } from '../types'
 import {
   DEFAULT_BTN_FONT_WEIGHT,
   DEFAULT_CONTAINER_BG,
+  DEFAULT_DIALOG_MAX_WIDTH,
+  DEFAULT_DIALOG_MIN_WIDTH,
   DEFAULT_DISABLED_CURSOR,
   DEFAULT_DISABLED_OPACITY,
   DEFAULT_FONT_MONO,
@@ -39,6 +41,7 @@ export const mazUi: ThemePreset = {
     btn: { 'font-weight': DEFAULT_BTN_FONT_WEIGHT },
     container: { bg: DEFAULT_CONTAINER_BG },
     input: { 'bg': DEFAULT_INPUT_BG, 'top-label-font-weight': DEFAULT_INPUT_TOP_LABEL_FONT_WEIGHT },
+    dialog: { 'max-width': DEFAULT_DIALOG_MAX_WIDTH, 'min-width': DEFAULT_DIALOG_MIN_WIDTH },
   },
   colors: {
     light: {

--- a/packages/themes/src/presets/nova.ts
+++ b/packages/themes/src/presets/nova.ts
@@ -2,6 +2,8 @@ import type { ThemePreset } from '../types'
 import {
   DEFAULT_BTN_FONT_WEIGHT,
   DEFAULT_CONTAINER_BG,
+  DEFAULT_DIALOG_MAX_WIDTH,
+  DEFAULT_DIALOG_MIN_WIDTH,
   DEFAULT_DISABLED_CURSOR,
   DEFAULT_DISABLED_OPACITY,
   DEFAULT_FONT_MONO,
@@ -59,6 +61,7 @@ export const nova: ThemePreset = {
     btn: { 'font-weight': DEFAULT_BTN_FONT_WEIGHT },
     container: { bg: DEFAULT_CONTAINER_BG },
     input: { 'bg': DEFAULT_INPUT_BG, 'top-label-font-weight': DEFAULT_INPUT_TOP_LABEL_FONT_WEIGHT },
+    dialog: { 'max-width': DEFAULT_DIALOG_MAX_WIDTH, 'min-width': DEFAULT_DIALOG_MIN_WIDTH },
   },
   colors: {
     light: {

--- a/packages/themes/src/presets/obsidian.ts
+++ b/packages/themes/src/presets/obsidian.ts
@@ -2,6 +2,8 @@ import type { ThemePreset } from '../types'
 import {
   DEFAULT_BTN_FONT_WEIGHT,
   DEFAULT_CONTAINER_BG,
+  DEFAULT_DIALOG_MAX_WIDTH,
+  DEFAULT_DIALOG_MIN_WIDTH,
   DEFAULT_DISABLED_CURSOR,
   DEFAULT_DISABLED_OPACITY,
   DEFAULT_FONT_MONO,
@@ -54,6 +56,7 @@ export const obsidian: ThemePreset = {
     btn: { 'font-weight': DEFAULT_BTN_FONT_WEIGHT },
     container: { bg: DEFAULT_CONTAINER_BG },
     input: { 'bg': DEFAULT_INPUT_BG, 'top-label-font-weight': DEFAULT_INPUT_TOP_LABEL_FONT_WEIGHT },
+    dialog: { 'max-width': DEFAULT_DIALOG_MAX_WIDTH, 'min-width': DEFAULT_DIALOG_MIN_WIDTH },
   },
   colors: {
     light: {

--- a/packages/themes/src/presets/ocean.ts
+++ b/packages/themes/src/presets/ocean.ts
@@ -55,6 +55,8 @@ export const ocean: ThemePreset = {
     btn: { 'font-weight': DEFAULT_BTN_FONT_WEIGHT },
     container: { bg: DEFAULT_CONTAINER_BG },
     input: { 'bg': DEFAULT_INPUT_BG, 'top-label-font-weight': DEFAULT_INPUT_TOP_LABEL_FONT_WEIGHT },
+    // rem scaled ×14/16 (16px base) to match the 14px presets' pixel width
+    dialog: { 'max-width': '33.25rem', 'min-width': '28rem' },
   },
   colors: {
     light: {

--- a/packages/themes/src/presets/pristine.ts
+++ b/packages/themes/src/presets/pristine.ts
@@ -2,6 +2,8 @@ import type { ThemePreset } from '../types'
 import {
   DEFAULT_BTN_FONT_WEIGHT,
   DEFAULT_CONTAINER_BG,
+  DEFAULT_DIALOG_MAX_WIDTH,
+  DEFAULT_DIALOG_MIN_WIDTH,
   DEFAULT_DISABLED_CURSOR,
   DEFAULT_DISABLED_OPACITY,
   DEFAULT_FONT_MONO,
@@ -57,6 +59,7 @@ export const pristine: ThemePreset = {
     btn: { 'font-weight': DEFAULT_BTN_FONT_WEIGHT },
     container: { bg: DEFAULT_CONTAINER_BG },
     input: { 'bg': DEFAULT_INPUT_BG, 'top-label-font-weight': DEFAULT_INPUT_TOP_LABEL_FONT_WEIGHT },
+    dialog: { 'max-width': DEFAULT_DIALOG_MAX_WIDTH, 'min-width': DEFAULT_DIALOG_MIN_WIDTH },
   },
   colors: {
     light: {

--- a/packages/themes/src/types/index.ts
+++ b/packages/themes/src/types/index.ts
@@ -163,6 +163,25 @@ export interface ThemeComponents {
      */
     'top-label-font-weight'?: string
   }
+  /**
+   * Dialog sizing on tablet and up (`MazDialog`). Both values map to
+   * `--maz-dialog-max-width` / `--maz-dialog-min-width` and are consumed by
+   * the component through `var(--maz-dialog-max-width, 38rem)` /
+   * `var(--maz-dialog-min-width, 32rem)`. The `max-width` / `min-width` props
+   * on `MazDialog` still override the preset per instance.
+   */
+  dialog?: {
+    /**
+     * Max-width of the dialog. Defaults to `'38rem'` (anchored on a 14px
+     * `base-font-size`).
+     */
+    'max-width'?: SizeUnit
+    /**
+     * Min-width of the dialog. Defaults to `'32rem'` (anchored on a 14px
+     * `base-font-size`).
+     */
+    'min-width'?: SizeUnit
+  }
 }
 
 export interface ThemePresetOverrides {

--- a/packages/themes/src/utils/__tests__/__snapshots__/css-generator.test.ts.snap
+++ b/packages/themes/src/utils/__tests__/__snapshots__/css-generator.test.ts.snap
@@ -31,6 +31,8 @@ exports[`given generateCSS function > when generating with mode=both and darkSel
     --maz-shadow-style-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
     --maz-shadow-style-elevation: 0 4px 12px -2px rgb(0 0 0 / 0.08), 0 2px 4px -1px rgb(0 0 0 / 0.06);
     --maz-btn-font-weight: 500;
+    --maz-dialog-max-width: 38rem;
+    --maz-dialog-min-width: 32rem;
     --maz-container-bg: var(--maz-surface);
     --maz-input-bg: light-dark(var(--maz-surface), oklch(from var(--maz-surface) clamp(0, calc(l + 0.06), 1) c h));
     --maz-input-top-label-font-weight: 600;

--- a/packages/themes/src/utils/__tests__/css-generator.test.ts
+++ b/packages/themes/src/utils/__tests__/css-generator.test.ts
@@ -531,6 +531,64 @@ describe('given generateCSS function', () => {
       })
     })
 
+    describe('when components.dialog max-width and min-width are provided', () => {
+      const preset = {
+        ...mazUi,
+        components: { dialog: { 'max-width': '40rem', 'min-width': '30rem' } as any },
+      }
+      const css = generateCSS(preset, {
+        prefix: 'maz',
+        mode: 'both',
+        darkSelectorStrategy: 'class',
+        darkClass: 'dark',
+      })
+
+      it('then --maz-dialog-max-width is emitted', () => {
+        expect(css).toContain('--maz-dialog-max-width: 40rem;')
+      })
+
+      it('then --maz-dialog-min-width is emitted', () => {
+        expect(css).toContain('--maz-dialog-min-width: 30rem;')
+      })
+
+      it('then the dialog vars are not wrapped per-mode', () => {
+        expect(css).not.toContain('--maz-dialog-max-width: light-dark(')
+      })
+    })
+
+    describe('when components.dialog has only max-width', () => {
+      const preset = {
+        ...mazUi,
+        components: { dialog: { 'max-width': '50rem' } as any },
+      }
+      const css = generateCSS(preset, {
+        prefix: 'maz',
+        mode: 'light',
+        darkSelectorStrategy: 'class',
+        darkClass: 'dark',
+      })
+
+      it('then only --maz-dialog-max-width is emitted', () => {
+        expect(css).toContain('--maz-dialog-max-width: 50rem;')
+        expect(css).not.toContain('--maz-dialog-min-width:')
+      })
+    })
+
+    describe('when components is provided without dialog sizing', () => {
+      const preset = { ...mazUi, components: { btn: { 'font-weight': '500' } } }
+      const css = generateCSS(preset, {
+        prefix: 'maz',
+        mode: 'light',
+        darkSelectorStrategy: 'class',
+        darkClass: 'dark',
+      })
+
+      it('then no dialog vars are emitted', () => {
+        expect(css).not.toContain('--maz-dialog-max-width:')
+        expect(css).not.toContain('--maz-dialog-min-width:')
+      })
+    })
+
     describe('when components is provided without container or input bg', () => {
       const preset = { ...mazUi, components: { btn: { 'font-weight': '700' } } }
       const css = generateCSS(preset, {

--- a/packages/themes/src/utils/__tests__/preset-merger.test.ts
+++ b/packages/themes/src/utils/__tests__/preset-merger.test.ts
@@ -327,6 +327,61 @@ describe('preset-merger', () => {
       })
     })
 
+    describe('when base declares dialog sizing and overrides change one side', () => {
+      it('then mergeComponents merges dialog and preserves the untouched side', () => {
+        const basePreset = {
+          name: 'base',
+          colors: { light: {}, dark: {} },
+          foundation: {},
+          scales: { rounded: {}, shadow: {} },
+          components: {
+            dialog: { 'max-width': '38rem', 'min-width': '32rem' },
+          },
+        } as unknown as ThemePreset
+
+        const overrides: ThemePresetOverrides = {
+          components: {
+            dialog: { 'max-width': '50rem' },
+          },
+        }
+
+        const result = mergePresets(basePreset, overrides)
+
+        expect(result.components?.dialog).toEqual({
+          'max-width': '50rem',
+          'min-width': '32rem',
+        })
+      })
+    })
+
+    describe('when base declares input top-label-font-weight and overrides change bg', () => {
+      it('then mergeComponents preserves the base top-label-font-weight', () => {
+        const basePreset = {
+          name: 'base',
+          colors: { light: {}, dark: {} },
+          foundation: {},
+          scales: { rounded: {}, shadow: {} },
+          components: {
+            input: { 'bg': { light: 'oklch(1 0 0)' }, 'top-label-font-weight': '600' },
+          },
+        } as unknown as ThemePreset
+
+        const overrides: ThemePresetOverrides = {
+          components: {
+            input: { bg: { dark: 'oklch(0.3 0 0)' } },
+          },
+        }
+
+        const result = mergePresets(basePreset, overrides)
+
+        expect(result.components?.input?.['top-label-font-weight']).toBe('600')
+        expect(result.components?.input?.bg).toEqual({
+          light: 'oklch(1 0 0)',
+          dark: 'oklch(0.3 0 0)',
+        })
+      })
+    })
+
     describe('when adding new properties from overrides', () => {
       it('then it adds new properties from overrides', () => {
         const basePreset = {

--- a/packages/themes/src/utils/css-generator.ts
+++ b/packages/themes/src/utils/css-generator.ts
@@ -109,6 +109,13 @@ function appendComponents(lines: string[], preset: ThemePreset, prefix: string, 
     lines.push(`    --${prefix}-btn-font-weight: ${components.btn['font-weight']};`)
   }
 
+  if (components.dialog?.['max-width']) {
+    lines.push(`    --${prefix}-dialog-max-width: ${components.dialog['max-width']};`)
+  }
+  if (components.dialog?.['min-width']) {
+    lines.push(`    --${prefix}-dialog-min-width: ${components.dialog['min-width']};`)
+  }
+
   const emitBg = (componentKey: 'container' | 'input', cssKey: string) => {
     const bg = components[componentKey]?.bg
     if (!bg)

--- a/packages/themes/src/utils/preset-merger.ts
+++ b/packages/themes/src/utils/preset-merger.ts
@@ -36,8 +36,11 @@ function mergeComponents(base?: ThemeComponents, overrides?: ThemeComponents): T
       bg: { ...base?.container?.bg, ...overrides?.container?.bg },
     },
     input: {
+      ...base?.input,
+      ...overrides?.input,
       bg: { ...base?.input?.bg, ...overrides?.input?.bg },
     },
+    dialog: { ...base?.dialog, ...overrides?.dialog },
   }
 }
 


### PR DESCRIPTION
## Summary

`MazDialog` width is now configurable from the **theme preset**, while remaining overridable per instance via the existing `max-width` / `min-width` props.

This finishes the WIP started on the branch (the preset/component values were inconsistent and not wired end-to-end).

## Changes

- **New `components.dialog` preset knobs** — `max-width` / `min-width`, emitted by the CSS generator as `--maz-dialog-max-width` / `--maz-dialog-min-width` (mode-independent, like `btn.font-weight`).
- **Component wiring** — `MazDialog` reads the vars with a fallback: `var(--maz-dialog-max-width, 38rem)` / `var(--maz-dialog-min-width, 32rem)`. The `min-width` default was previously a raw `32rem`, now symmetrical with `max-width`.
- **All presets ship the defaults.** Widths are in `rem`, so `ocean` (16px base) uses scaled rem (`33.25rem` / `28rem`) to keep the **same rendered pixel width** as the 14px presets (≈532px / ≈448px).
- **`mergePresets` fix** — now merges `components.dialog`, and stops silently dropping `input.top-label-font-weight` (latent bug in the manual whitelist). `definePreset` overrides are now preserved.
- **Docs** — `maz-dialog.md` (width section + demo) and `themes.md` (`Dialog sizing` section + Components token table).

## Usage

```ts
import { definePreset } from '@maz-ui/themes'

const theme = definePreset({
  base: 'maz-ui',
  overrides: {
    components: {
      dialog: { 'max-width': '48rem', 'min-width': '36rem' },
    },
  },
})
```

```vue
<!-- Per-instance override still wins over the preset -->
<MazDialog v-model="open" max-width="50rem" min-width="40rem" />
```

## Tests

- `@maz-ui/themes`: dialog var emission (css-generator) + `dialog` / `top-label-font-weight` merge preservation (preset-merger) + updated snapshot. Full suite green (340).
- `maz-ui`: updated `MazDialog` default-vars assertion. Full coverage run green (3121 tests, thresholds met).
