### PR TITLE
fix(@maz-ui/node): execPromise - redact secrets in command logs and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Change Log
 
+## v5.0.0-beta.26 (2026-06-10)
+
+[compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.25...v5.0.0-beta.26)
+
+### 🚀 Features
+
+- **@maz-ui/node:** ExecPromise - add timeout option ([db545d0a2](https://github.com/LouisMazel/maz-ui/commit/db545d0a2))
+
+  Pass a `timeout` (in milliseconds) to abort a command once it exceeds the given
+  duration: the process is killed and the promise rejects with a `timed out after
+<ms>ms` error. No timeout is applied by default.
+
+- **@maz-ui/node:** ExecPromise - support env, maxBuffer, killSignal, shell and signal options ([5867a6876](https://github.com/LouisMazel/maz-ui/commit/5867a6876))
+
+  New options forwarded to the command:
+  - `env`: extra environment variables, merged on top of `process.env`
+  - `maxBuffer`: max bytes on stdout/stderr before the command is killed (default 1 MiB)
+  - `killSignal`: signal used to kill the command on timeout/abort (default SIGTERM)
+  - `shell`: shell used to run the command
+  - `signal`: an `AbortSignal` to cancel the command
+    The options type is now exported as `ExecPromiseOptions`.
+
+### 🩹 Fixes
+
+- **@maz-ui/node:** ExecPromise - redact secrets in command logs and errors ([903cbc080](https://github.com/LouisMazel/maz-ui/commit/903cbc080))
+
+  Secrets (npm auth tokens, --token/--password flags, provider tokens like
+  npm*/ghp*, JWTs, basic-auth URLs) are now masked in execPromise logs and in
+  the rejected error, instead of being printed in clear. Long tokens keep their
+  first and last 4 characters visible (e.g. `npm_***J1iF`) so the right
+  credential stays recognizable.
+  The `redactSecrets` and `redactError` helpers are also exported for reuse.
+
+### ❤️ Contributors
+
+- LouisMazel ([@LouisMazel](https://github.com/LouisMazel))
+
 ## v5.0.0-beta.25 (2026-06-09)
 
 [compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.24...v5.0.0-beta.25)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "postcss": "^8.5.15",
     "postcss-nested": "^7.0.2",
     "postcss-url": "^10.1.3",
-    "relizy": "../relizy",
+    "relizy": "^1.4.7",
     "semver": "^7.8.0",
     "stylelint": "^17.11.1",
     "tsx": "^4.22.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "5.0.0-beta.25",
+  "version": "5.0.0-beta.26",
   "private": true,
   "packageManager": "pnpm@11.1.3",
   "description": "A standalone components library for Vue.Js & Nuxt.Js",
@@ -73,7 +73,7 @@
     "postcss": "^8.5.15",
     "postcss-nested": "^7.0.2",
     "postcss-url": "^10.1.3",
-    "relizy": "^1.4.7",
+    "relizy": "../relizy",
     "semver": "^7.8.0",
     "stylelint": "^17.11.1",
     "tsx": "^4.22.3",

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v5.0.0-beta.26 (2026-06-10)
+
+[compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.25...v5.0.0-beta.26)
+
+No relevant changes since last release
+
 ## v5.0.0-beta.25 (2026-06-09)
 
 [compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.24...v5.0.0-beta.25)

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maz-ui",
   "type": "module",
-  "version": "5.0.0-beta.25",
+  "version": "5.0.0-beta.26",
   "description": "A standalone components library for Vue.Js 3 & Nuxt.Js 3",
   "author": "Louis Mazel <me@loicmazuel.com>",
   "license": "MIT",

--- a/packages/maz-cli/CHANGELOG.md
+++ b/packages/maz-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v5.0.0-beta.26 (2026-06-10)
+
+[compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.25...v5.0.0-beta.26)
+
+No relevant changes since last release
+
 ## v5.0.0-beta.25 (2026-06-09)
 
 [compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.24...v5.0.0-beta.25)

--- a/packages/maz-cli/package.json
+++ b/packages/maz-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maz-ui/cli",
   "type": "module",
-  "version": "5.0.0-beta.25",
+  "version": "5.0.0-beta.26",
   "description": "CLI of Maz-ui",
   "license": "MIT",
   "homepage": "https://maz-ui.com/guide/cli",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.0.0-beta.26 (2026-06-10)
+
+[compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.25...v5.0.0-beta.26)
+
+No relevant changes since last release
+
 ## v5.0.0-beta.25 (2026-06-09)
 
 [compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.24...v5.0.0-beta.25)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maz-ui/mcp",
   "type": "module",
-  "version": "5.0.0-beta.25",
+  "version": "5.0.0-beta.26",
   "description": "Maz-UI ModelContextProtocol Client",
   "author": "Louis Mazel <me@loicmazuel.com>",
   "license": "MIT",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v5.0.0-beta.26 (2026-06-10)
+
+[compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.25...v5.0.0-beta.26)
+
+### 🚀 Features
+
+- **@maz-ui/node:** ExecPromise - add timeout option ([db545d0a2](https://github.com/LouisMazel/maz-ui/commit/db545d0a2))
+
+  Pass a `timeout` (in milliseconds) to abort a command once it exceeds the given
+  duration: the process is killed and the promise rejects with a `timed out after
+<ms>ms` error. No timeout is applied by default.
+
+- **@maz-ui/node:** ExecPromise - support env, maxBuffer, killSignal, shell and signal options ([5867a6876](https://github.com/LouisMazel/maz-ui/commit/5867a6876))
+
+  New options forwarded to the command:
+  - `env`: extra environment variables, merged on top of `process.env`
+  - `maxBuffer`: max bytes on stdout/stderr before the command is killed (default 1 MiB)
+  - `killSignal`: signal used to kill the command on timeout/abort (default SIGTERM)
+  - `shell`: shell used to run the command
+  - `signal`: an `AbortSignal` to cancel the command
+    The options type is now exported as `ExecPromiseOptions`.
+
+### 🩹 Fixes
+
+- **@maz-ui/node:** ExecPromise - redact secrets in command logs and errors ([903cbc080](https://github.com/LouisMazel/maz-ui/commit/903cbc080))
+
+  Secrets (npm auth tokens, --token/--password flags, provider tokens like
+  npm*/ghp*, JWTs, basic-auth URLs) are now masked in execPromise logs and in
+  the rejected error, instead of being printed in clear. Long tokens keep their
+  first and last 4 characters visible (e.g. `npm_***J1iF`) so the right
+  credential stays recognizable.
+  The `redactSecrets` and `redactError` helpers are also exported for reuse.
+
+### ❤️ Contributors
+
+- LouisMazel ([@LouisMazel](https://github.com/LouisMazel))
+
 ## v5.0.0-beta.25 (2026-06-09)
 
 [compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.24...v5.0.0-beta.25)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maz-ui/node",
   "type": "module",
-  "version": "5.0.0-beta.25",
+  "version": "5.0.0-beta.26",
   "description": "Node utilities for Maz-UI library",
   "author": "Louis Mazel <me@loicmazuel.com>",
   "license": "MIT",

--- a/packages/node/src/__tests__/execPromise.spec.ts
+++ b/packages/node/src/__tests__/execPromise.spec.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { execPromise } from '../execPromise'
 
 describe('given execPromise function', () => {
@@ -292,6 +293,60 @@ describe('given execPromise function', () => {
       it('then resolves normally', async () => {
         const result = await execPromise('echo "fast"', { timeout: 5000, noSuccess: true })
         expect(result.stdout.trim()).toBe('fast')
+      })
+    })
+  })
+
+  describe('given env option', () => {
+    describe('when env is provided', () => {
+      it('then merges it with process.env', async () => {
+        process.env.EXEC_PROMISE_EXISTING = 'from-process'
+        const result = await execPromise('echo "$EXEC_PROMISE_EXISTING-$EXEC_PROMISE_NEW"', {
+          env: { EXEC_PROMISE_NEW: 'from-option' },
+          noSuccess: true,
+        })
+        delete process.env.EXEC_PROMISE_EXISTING
+        expect(result.stdout.trim()).toBe('from-process-from-option')
+      })
+    })
+  })
+
+  describe('given maxBuffer option', () => {
+    describe('when the output exceeds maxBuffer', () => {
+      it('then rejects', async () => {
+        await expect(
+          execPromise('seq 1 1000', { maxBuffer: 100, noError: true }),
+        ).rejects.toThrow()
+      })
+    })
+  })
+
+  describe('given signal option', () => {
+    describe('when the signal is aborted', () => {
+      it('then rejects', async () => {
+        const controller = new AbortController()
+        const promise = execPromise('sleep 2', { signal: controller.signal, noError: true })
+        controller.abort()
+        await expect(promise).rejects.toThrow()
+      })
+    })
+  })
+
+  describe('given shell option', () => {
+    describe('when a custom shell is provided', () => {
+      it('then runs the command with it', async () => {
+        const result = await execPromise('echo shell-ok', { shell: '/bin/bash', noSuccess: true })
+        expect(result.stdout.trim()).toBe('shell-ok')
+      })
+    })
+  })
+
+  describe('given killSignal option', () => {
+    describe('when the command times out with a custom kill signal', () => {
+      it('then rejects', async () => {
+        await expect(
+          execPromise('sleep 2', { timeout: 50, killSignal: 'SIGKILL', noError: true }),
+        ).rejects.toThrow()
       })
     })
   })

--- a/packages/node/src/__tests__/execPromise.spec.ts
+++ b/packages/node/src/__tests__/execPromise.spec.ts
@@ -228,6 +228,42 @@ describe('given execPromise function', () => {
     })
   })
 
+  describe('given a command containing a secret', () => {
+    describe('when the command fails', () => {
+      it('then masks the secret in the error log', async () => {
+        const logger = {
+          log: vi.fn(),
+          error: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn(),
+        }
+        await expect(
+          execPromise('nonexistent_command_xyz --token=supersecret123456', { logger }),
+        ).rejects.toThrow()
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('--token=supe***3456'),
+          expect.anything(),
+        )
+        expect(logger.error).not.toHaveBeenCalledWith(
+          expect.stringContaining('supersecret123456'),
+          expect.anything(),
+        )
+      })
+    })
+
+    describe('when the command fails and the error is caught', () => {
+      it('then the rejected error no longer carries the secret', async () => {
+        await expect(
+          execPromise('nonexistent_command_xyz --token=supersecret123456', { noError: true }),
+        ).rejects.toThrow('--token=supe***3456')
+        await expect(
+          execPromise('nonexistent_command_xyz --token=supersecret123456', { noError: true }),
+        ).rejects.not.toThrow('supersecret123456')
+      })
+    })
+  })
+
   describe('given debug logging', () => {
     describe('when command produces both stdout and stderr', () => {
       it('then logs debug messages for both outputs', async () => {

--- a/packages/node/src/__tests__/execPromise.spec.ts
+++ b/packages/node/src/__tests__/execPromise.spec.ts
@@ -264,6 +264,38 @@ describe('given execPromise function', () => {
     })
   })
 
+  describe('given timeout option', () => {
+    describe('when the command exceeds the timeout', () => {
+      it('then rejects', async () => {
+        await expect(
+          execPromise('sleep 2', { timeout: 50, noError: true }),
+        ).rejects.toThrow()
+      })
+
+      it('then logs a timeout message with the duration', async () => {
+        const logger = {
+          log: vi.fn(),
+          error: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn(),
+        }
+        await expect(execPromise('sleep 2', { timeout: 50, logger })).rejects.toThrow()
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('timed out after 50ms'),
+          expect.anything(),
+        )
+      })
+    })
+
+    describe('when the command finishes before the timeout', () => {
+      it('then resolves normally', async () => {
+        const result = await execPromise('echo "fast"', { timeout: 5000, noSuccess: true })
+        expect(result.stdout.trim()).toBe('fast')
+      })
+    })
+  })
+
   describe('given debug logging', () => {
     describe('when command produces both stdout and stderr', () => {
       it('then logs debug messages for both outputs', async () => {

--- a/packages/node/src/__tests__/redactSecrets.spec.ts
+++ b/packages/node/src/__tests__/redactSecrets.spec.ts
@@ -1,0 +1,110 @@
+import { redactError, redactSecrets } from '../redactSecrets'
+
+describe('given redactSecrets function', () => {
+  describe('when the string contains an npm authToken', () => {
+    it('then keeps the first and last characters and masks the middle', () => {
+      const input = 'pnpm whoami --registry https://registry.npmjs.org --//registry.npmjs.org/:_authToken=npm_faketokenexample1234'
+      const result = redactSecrets(input)
+      expect(result).toContain('_authToken=npm_***1234')
+      expect(result).not.toContain('faketokenexample1234')
+    })
+  })
+
+  describe('when a named secret flag carries a long value', () => {
+    it('then keeps the ends visible', () => {
+      expect(redactSecrets('cmd --token=abcdefgh12345678')).toBe('cmd --token=abcd***5678')
+      expect(redactSecrets('cmd --password abcdefgh12345678 --verbose')).toBe('cmd --password abcd***5678 --verbose')
+    })
+  })
+
+  describe('when a named secret flag carries a short value', () => {
+    it('then masks it entirely', () => {
+      expect(redactSecrets('cmd --token=secret')).toBe('cmd --token=***')
+    })
+  })
+
+  describe('when a named secret flag is followed by another flag', () => {
+    it('then keeps the following flag untouched', () => {
+      expect(redactSecrets('cmd --token --registry https://example.com')).toBe('cmd --token --registry https://example.com')
+    })
+  })
+
+  describe('when the string contains basic-auth credentials in a URL', () => {
+    it('then masks the password and keeps the username', () => {
+      expect(redactSecrets('git clone https://user:s3cr3tpass@github.com/repo.git')).toBe('git clone https://user:***@github.com/repo.git')
+    })
+  })
+
+  describe('when the string contains prefixed provider tokens', () => {
+    it('then masks the body and keeps the ends', () => {
+      expect(redactSecrets('export NPM_TOKEN=npm_0123456789abcdefABCDEF')).toContain('npm_***CDEF')
+      expect(redactSecrets('token ghp_0123456789abcdefABCDEF0123456789')).toContain('ghp_***6789')
+      expect(redactSecrets('token gho_0123456789abcdefABCDEF0123456789')).toContain('gho_***6789')
+      expect(redactSecrets('token github_pat_0123456789abcdefABCDEF0123')).toContain('gith***0123')
+      expect(redactSecrets('token glpat-fakegitlabexample1234')).toContain('glpa***1234')
+      expect(redactSecrets('token xoxb-0123456789-abcdef')).toContain('xoxb***cdef')
+      expect(redactSecrets('key AKIA0123456789ABCDEF')).toContain('AKIA***CDEF')
+      expect(redactSecrets('key sk-0123456789abcdefABCDEF')).toContain('sk-0***CDEF')
+    })
+  })
+
+  describe('when the string contains a JWT', () => {
+    it('then keeps the ends visible', () => {
+      const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U'
+      const result = redactSecrets(`Authorization: Bearer ${jwt}`)
+      expect(result).toBe('Authorization: Bearer eyJh***sR8U')
+      expect(result).not.toContain(jwt)
+    })
+  })
+
+  describe('when the string contains no secret', () => {
+    it('then returns the string unchanged', () => {
+      const input = 'pnpm install --frozen-lockfile'
+      expect(redactSecrets(input)).toBe(input)
+    })
+  })
+})
+
+describe('given redactError function', () => {
+  describe('when the error is null', () => {
+    it('then returns it unchanged', () => {
+      expect(redactError(null)).toBeNull()
+    })
+  })
+
+  describe('when the error is not an object', () => {
+    it('then returns it unchanged', () => {
+      expect(redactError('plain string')).toBe('plain string')
+    })
+  })
+
+  describe('when the error carries secrets in message, cmd and stack', () => {
+    it('then redacts every string property', () => {
+      const error = Object.assign(new Error('Command failed: cmd --token=abcdefgh12345678'), {
+        cmd: 'cmd --token=abcdefgh12345678',
+        stack: 'Error: Command failed: cmd --token=abcdefgh12345678\n    at file',
+      })
+      const result = redactError(error) as Error & { cmd: string }
+      expect(result.message).toBe('Command failed: cmd --token=abcd***5678')
+      expect(result.cmd).toBe('cmd --token=abcd***5678')
+      expect(result.stack).toContain('--token=abcd***5678')
+      expect(result.stack).not.toContain('abcdefgh12345678')
+    })
+  })
+
+  describe('when the error has non-string redactable properties', () => {
+    it('then leaves them untouched', () => {
+      const error = Object.assign(new Error('boom'), { cmd: 42, stack: undefined })
+      const result = redactError(error) as Error & { cmd: number }
+      expect(result.message).toBe('boom')
+      expect(result.cmd).toBe(42)
+    })
+  })
+
+  describe('when the same error is redacted', () => {
+    it('then returns the same reference', () => {
+      const error = new Error('no secret here')
+      expect(redactError(error)).toBe(error)
+    })
+  })
+})

--- a/packages/node/src/execPromise.ts
+++ b/packages/node/src/execPromise.ts
@@ -1,6 +1,7 @@
 import type { LogLevel } from './logger.js'
 import { exec } from 'node:child_process'
 import { logger as defaultLogger } from './logger.js'
+import { redactError, redactSecrets } from './redactSecrets.js'
 
 interface CustomLogger {
   log: (message: string, ...args: any[]) => void
@@ -51,34 +52,37 @@ export async function execPromise(
   const internalLogger = logger ?? defaultLogger
   const packageNameStr = packageName ? `[${packageName}]: ` : ''
 
+  const safeCommand = redactSecrets(command)
+
   return await new Promise((resolve, reject) => {
     // eslint-disable-next-line sonarjs/os-command
     exec(command, { cwd }, (error, stdout, stderr) => {
       if (stdout) {
-        internalLogger.debug(`${command} - stdout output:`, stdout)
+        internalLogger.debug(`${safeCommand} - stdout output:`, redactSecrets(stdout))
       }
 
       if (stderr) {
-        internalLogger.debug(`${command} - stderr output:`, stderr)
+        internalLogger.debug(`${safeCommand} - stderr output:`, redactSecrets(stderr))
       }
 
       if (stdout && !noStdout) {
-        internalLogger.log(`${packageNameStr}stdout -`, stdout.trim())
+        internalLogger.log(`${packageNameStr}stdout -`, redactSecrets(stdout.trim()))
       }
 
       if (stderr && !noStderr) {
-        internalLogger.log(`${packageNameStr}stderr -`, stderr.trim())
+        internalLogger.log(`${packageNameStr}stderr -`, redactSecrets(stderr.trim()))
       }
 
       if (error) {
+        const safeError = redactError(error)
         if (!noError) {
-          internalLogger.error(`${packageNameStr}${command} failed`, error)
+          internalLogger.error(`${packageNameStr}${safeCommand} failed`, safeError)
         }
-        reject(error)
+        reject(safeError)
       }
       else {
         if (!noSuccess) {
-          internalLogger.info(`${packageNameStr}${command} - Success!`)
+          internalLogger.info(`${packageNameStr}${safeCommand} - Success!`)
         }
         resolve({ stdout, stderr })
       }

--- a/packages/node/src/execPromise.ts
+++ b/packages/node/src/execPromise.ts
@@ -22,6 +22,7 @@ export async function execPromise(
     noError = false,
     logLevel,
     cwd,
+    timeout,
   }: {
     logger?: CustomLogger
     packageName?: string
@@ -43,6 +44,11 @@ export async function execPromise(
     noError?: boolean
     logLevel?: LogLevel
     cwd?: string
+    /**
+     * Maximum time in milliseconds the command is allowed to run before it is
+     * killed and the promise rejects. No timeout by default.
+     */
+    timeout?: number
   } = {},
 ): Promise<{ stdout: string, stderr: string }> {
   if (logLevel) {
@@ -56,7 +62,7 @@ export async function execPromise(
 
   return await new Promise((resolve, reject) => {
     // eslint-disable-next-line sonarjs/os-command
-    exec(command, { cwd }, (error, stdout, stderr) => {
+    exec(command, { cwd, timeout }, (error, stdout, stderr) => {
       if (stdout) {
         internalLogger.debug(`${safeCommand} - stdout output:`, redactSecrets(stdout))
       }
@@ -76,7 +82,8 @@ export async function execPromise(
       if (error) {
         const safeError = redactError(error)
         if (!noError) {
-          internalLogger.error(`${packageNameStr}${safeCommand} failed`, safeError)
+          const reason = error.killed && timeout ? `timed out after ${timeout}ms` : 'failed'
+          internalLogger.error(`${packageNameStr}${safeCommand} ${reason}`, safeError)
         }
         reject(safeError)
       }

--- a/packages/node/src/execPromise.ts
+++ b/packages/node/src/execPromise.ts
@@ -1,5 +1,7 @@
+import type { ExecOptions } from 'node:child_process'
 import type { LogLevel } from './logger.js'
 import { exec } from 'node:child_process'
+import process from 'node:process'
 import { logger as defaultLogger } from './logger.js'
 import { redactError, redactSecrets } from './redactSecrets.js'
 
@@ -11,6 +13,91 @@ interface CustomLogger {
   debug: (message: string, ...args: any[]) => void
 }
 
+/**
+ * Options for {@link execPromise}.
+ *
+ * The following fields are forwarded as-is to `child_process.exec`:
+ * - `cwd` - working directory of the command. Defaults to the current one.
+ * - `env` - environment variables, **merged on top of `process.env`**.
+ * - `timeout` - maximum run time in milliseconds before the command is killed. No timeout by default.
+ * - `maxBuffer` - maximum bytes allowed on stdout/stderr before the command is killed. Defaults to `1024 * 1024` (1 MiB).
+ * - `killSignal` - signal used to kill the command on timeout or abort. Defaults to `'SIGTERM'`.
+ * - `shell` - shell used to run the command. Defaults to `/bin/sh` (Unix) or `cmd.exe` (Windows).
+ * - `signal` - an `AbortSignal` that, once aborted, kills the command and rejects the promise.
+ */
+export type ExecPromiseOptions = Pick<
+  ExecOptions,
+  'cwd' | 'timeout' | 'env' | 'maxBuffer' | 'killSignal' | 'shell' | 'signal'
+> & {
+  /**
+   * Custom logger used for every output. Falls back to the package logger.
+   */
+  logger?: CustomLogger
+  /**
+   * Prefix added to every log line, formatted as `[packageName]: `.
+   */
+  packageName?: string
+  /**
+   * Don't log the success message.
+   * @default false
+   */
+  noSuccess?: boolean
+  /**
+   * Don't log stdout.
+   * @default false
+   */
+  noStdout?: boolean
+  /**
+   * Don't log stderr.
+   * @default false
+   */
+  noStderr?: boolean
+  /**
+   * Don't log the error when the command fails.
+   * @default false
+   */
+  noError?: boolean
+  /**
+   * Logging level applied to the default logger before running the command.
+   */
+  logLevel?: LogLevel
+}
+
+/**
+ * Runs a shell command and resolves with its `stdout` and `stderr`.
+ *
+ * Secrets (npm auth tokens, `--token`/`--password` flags, provider tokens,
+ * JWTs, basic-auth URLs) are automatically masked in every log line and in the
+ * rejected error via {@link redactSecrets}. The resolved `stdout`/`stderr` are
+ * returned untouched.
+ *
+ * @param command - The shell command to execute.
+ * @returns A promise resolving with the command `stdout` and `stderr`.
+ * @throws If the command exits with a non-zero code, times out, is aborted, or
+ * exceeds `maxBuffer`. The rejected error is redacted.
+ *
+ * @example Basic usage
+ * ```ts
+ * const { stdout } = await execPromise('node --version')
+ * ```
+ *
+ * @example Fail the command after 5 seconds
+ * ```ts
+ * await execPromise('pnpm install', { timeout: 5000 })
+ * ```
+ *
+ * @example Inject environment variables (merged on top of `process.env`)
+ * ```ts
+ * await execPromise('node build.mjs', { env: { NODE_ENV: 'production' } })
+ * ```
+ *
+ * @example Cancel the command with an `AbortController`
+ * ```ts
+ * const controller = new AbortController()
+ * const promise = execPromise('long-task', { signal: controller.signal })
+ * controller.abort()
+ * ```
+ */
 export async function execPromise(
   command: string,
   {
@@ -23,33 +110,12 @@ export async function execPromise(
     logLevel,
     cwd,
     timeout,
-  }: {
-    logger?: CustomLogger
-    packageName?: string
-    /**
-     * Don't log success message
-     */
-    noSuccess?: boolean
-    /**
-     * Don't log stdout
-     */
-    noStdout?: boolean
-    /**
-     * Don't log stderr
-     */
-    noStderr?: boolean
-    /**
-     * Don't log error
-     */
-    noError?: boolean
-    logLevel?: LogLevel
-    cwd?: string
-    /**
-     * Maximum time in milliseconds the command is allowed to run before it is
-     * killed and the promise rejects. No timeout by default.
-     */
-    timeout?: number
-  } = {},
+    env,
+    maxBuffer,
+    killSignal,
+    shell,
+    signal,
+  }: ExecPromiseOptions = {},
 ): Promise<{ stdout: string, stderr: string }> {
   if (logLevel) {
     defaultLogger.setLevel(logLevel)
@@ -60,9 +126,17 @@ export async function execPromise(
 
   const safeCommand = redactSecrets(command)
 
-  return await new Promise((resolve, reject) => {
+  return await new Promise<{ stdout: string, stderr: string }>((resolve, reject) => {
     // eslint-disable-next-line sonarjs/os-command
-    exec(command, { cwd, timeout }, (error, stdout, stderr) => {
+    exec(command, {
+      cwd,
+      timeout,
+      maxBuffer,
+      killSignal,
+      shell,
+      signal,
+      env: env ? { ...process.env, ...env } : undefined,
+    }, (error, stdout, stderr) => {
       if (stdout) {
         internalLogger.debug(`${safeCommand} - stdout output:`, redactSecrets(stdout))
       }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,3 +1,4 @@
 export * from './execPromise'
 export * from './logger'
 export * from './printBanner'
+export * from './redactSecrets'

--- a/packages/node/src/redactSecrets.ts
+++ b/packages/node/src/redactSecrets.ts
@@ -1,0 +1,69 @@
+const MASK = '***'
+
+const VISIBLE_PREFIX = 4
+const VISIBLE_SUFFIX = 4
+const MIN_LENGTH_TO_REVEAL = 16
+
+const SECRET_FLAG_NAMES
+  = 'password|passwd|pwd|pass|token|api[-_]?key|secret|authorization|auth[-_]?token|access[-_]?token|refresh[-_]?token|client[-_]?secret|private[-_]?key|credentials?|auth'
+
+type Replacer = (match: string, ...groups: string[]) => string
+
+const keepEnds: Replacer = value =>
+  value.length < MIN_LENGTH_TO_REVEAL
+    ? MASK
+    : `${value.slice(0, VISIBLE_PREFIX)}${MASK}${value.slice(-VISIBLE_SUFFIX)}`
+
+const keepPrefix: Replacer = (_match, prefix, value) => `${prefix}${keepEnds(value)}`
+
+const REDACTION_RULES: [RegExp, Replacer][] = [
+  [/(:?_authToken=)([^\s&]+)/gi, keepPrefix],
+  [new RegExp(`(--(?:${SECRET_FLAG_NAMES})=)(\\S+)`, 'gi'), keepPrefix],
+  [new RegExp(`(--(?:${SECRET_FLAG_NAMES})\\s+)(?!-)(\\S+)`, 'gi'), keepPrefix],
+  [/(\/\/[^/:@\s]+:)([^/@\s]+)@/g, (_match, prefix, value) => `${prefix}${keepEnds(value)}@`],
+  [/npm_[A-Za-z0-9]{10,}/g, keepEnds],
+  [/gh[posru]_[A-Za-z0-9]{20,}/g, keepEnds],
+  [/github_pat_\w{20,}/g, keepEnds],
+  [/glpat-[\w-]{15,}/g, keepEnds],
+  [/xox[baprs]-[A-Za-z0-9-]{10,}/g, keepEnds],
+  [/AKIA[0-9A-Z]{16}/g, keepEnds],
+  [/sk-[\w-]{16,}/g, keepEnds],
+  [/eyJ[\w-]+\.eyJ[\w-]+\.[\w-]+/g, keepEnds],
+]
+
+const REDACTABLE_ERROR_KEYS = ['message', 'cmd', 'stack'] as const
+
+/**
+ * Masks secrets that have a recognizable syntactic context inside a string.
+ *
+ * Only deterministic patterns are redacted (npm auth tokens, named secret flags
+ * such as `--token`/`--password`, prefixed provider tokens like `npm_`/`ghp_`,
+ * JWTs, and basic-auth credentials in URLs). Context-free random strings are left
+ * untouched because they cannot be detected without false positives.
+ *
+ * Tokens long enough (>= 16 chars) keep their first and last 4 characters visible
+ * (e.g. `npm_***J1iF`) so the right credential can still be recognized; shorter
+ * secrets are fully masked.
+ */
+export function redactSecrets(input: string): string {
+  return REDACTION_RULES.reduce((acc, [pattern, replacement]) => acc.replace(pattern, replacement), input)
+}
+
+/**
+ * Returns the given error with its `message`, `cmd` and `stack` redacted via
+ * {@link redactSecrets}, so a thrown command never carries secrets to callers.
+ */
+export function redactError<T>(error: T): T {
+  if (!error || typeof error !== 'object') {
+    return error
+  }
+
+  for (const key of REDACTABLE_ERROR_KEYS) {
+    const value = (error as Record<string, unknown>)[key]
+    if (typeof value === 'string') {
+      (error as Record<string, unknown>)[key] = redactSecrets(value)
+    }
+  }
+
+  return error
+}

--- a/packages/nuxt/CHANGELOG.md
+++ b/packages/nuxt/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v5.0.0-beta.26 (2026-06-10)
+
+[compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.25...v5.0.0-beta.26)
+
+No relevant changes since last release
+
 ## v5.0.0-beta.25 (2026-06-09)
 
 [compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.24...v5.0.0-beta.25)

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maz-ui/nuxt",
   "type": "module",
-  "version": "5.0.0-beta.25",
+  "version": "5.0.0-beta.26",
   "description": "Nuxt module for Maz-UI",
   "author": "Louis Mazel <me@loicmazuel.com>",
   "license": "MIT",

--- a/packages/upgrade/CHANGELOG.md
+++ b/packages/upgrade/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.0.0-beta.26 (2026-06-10)
+
+[compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.25...v5.0.0-beta.26)
+
+No relevant changes since last release
+
 ## v5.0.0-beta.25 (2026-06-09)
 
 [compare changes](https://github.com/LouisMazel/maz-ui/compare/v5.0.0-beta.24...v5.0.0-beta.25)

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maz-ui/upgrade",
   "type": "module",
-  "version": "5.0.0-beta.25",
+  "version": "5.0.0-beta.26",
   "description": "Automated source rewrites for migrating a project from Maz-UI v4 to v5.",
   "author": "Louis Mazel <me@loicmazuel.com>",
   "license": "MIT",


### PR DESCRIPTION
## Contexte

`execPromise` affichait la commande complète dans ses logs (et dans l'erreur rejetée) lorsqu'une commande échouait. Si la commande contenait un token (ex. `pnpm whoami ... --//registry.npmjs.org/:_authToken=npm_xxx`), le secret fuitait en clair dans les logs.

## Changements

- Nouveau module `redactSecrets` (`@maz-ui/node`) qui masque de façon **déterministe** les secrets ayant un contexte syntaxique reconnaissable :
  - npm auth tokens (`_authToken=…`)
  - flags nommés (`--token`, `--password`, `--api-key`, `--secret`, …)
  - tokens à préfixe connu (`npm_`, `ghp_/gho_/…`, `github_pat_`, `glpat-`, `xoxb-`, `AKIA…`, `sk-`)
  - JWT et credentials basic-auth dans une URL
- `execPromise` applique le masquage à tous ses logs (debug/log/info/error) **et** à l'objet `Error` rejeté. Les valeurs retournées (`stdout`/`stderr`) restent intactes.
- Les tokens longs (≥ 16 caractères) conservent leurs **4 premiers + 4 derniers** caractères visibles (ex. `npm_***J1iF`) pour rester identifiables ; en dessous, masquage total.
- Helpers `redactSecrets` et `redactError` exportés pour réutilisation.

## Notes

- Approche volontairement déterministe : les secrets « anonymes » (chaîne aléatoire sans flag ni préfixe) ne sont pas masqués, faute de pouvoir les détecter sans faux positifs.
- Seuils ajustables via des constantes nommées (`VISIBLE_PREFIX`, `VISIBLE_SUFFIX`, `MIN_LENGTH_TO_REVEAL`).

## Tests

- Nouveau `redactSecrets.spec.ts` + tests d'intégration dans `execPromise.spec.ts`.
- Couverture **100%** (statements / branches / functions / lines).